### PR TITLE
CLC-8002, Ripley gets schema.sql

### DIFF
--- a/application.py
+++ b/application.py
@@ -55,7 +55,8 @@ application = create_app()
 
 @application.cli.command()
 def initdb():
-    pass
+    from ripley.models import development_db
+    development_db.load(create_test_data=False)
 
 
 host = application.config['HOST']

--- a/config/default.py
+++ b/config/default.py
@@ -24,6 +24,10 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 import logging
+import os
+
+# Base directory for the application (one level up from this config file).
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
 DEV_AUTH_ENABLED = False
 DEV_AUTH_PASSWORD = 'another secret'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,15 @@
 Flask==2.2.2
 Flask-Login==0.6.2
+Flask-SQLAlchemy==3.0.2
+psycopg2-binary==2.9.5
 python-dateutil==2.8.2
 pytz==2022.7.1
 simplejson==3.18.1
+SQLAlchemy==1.4.46
 Werkzeug==2.2.2
+https://github.com/python-cas/python-cas/archive/master.zip
 
 # For testing
 pytest==7.2.1
 pytest-flask==1.2.0
-tox==4.3.5
+tox==4.4.0

--- a/scripts/db/drop_schema.sql
+++ b/scripts/db/drop_schema.sql
@@ -1,0 +1,59 @@
+/**
+ * Copyright ©2022. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+
+ALTER TABLE IF EXISTS ONLY public.canvas_site_mailing_list_members
+    DROP CONSTRAINT IF EXISTS canvas_site_mailing_list_members_unique_constraint;
+ALTER TABLE IF EXISTS ONLY public.canvas_site_mailing_lists
+    DROP CONSTRAINT IF EXISTS canvas_site_mailing_lists_unique_constraint;
+ALTER TABLE IF EXISTS ONLY public.user_auths
+    DROP CONSTRAINT IF EXISTS user_auths_unique_constraint;
+ALTER TABLE IF EXISTS ONLY public.user_data
+    DROP CONSTRAINT IF EXISTS user_data_unique_constraint;
+
+--
+
+DROP INDEX IF EXISTS public.canvas_site_mailing_list_members_deleted_at_idx;
+DROP INDEX IF EXISTS public.canvas_site_mailing_list_members_welcomed_at_idx;
+
+--
+
+DROP TABLE IF EXISTS public.canvas_site_mailing_list_members;
+DROP TABLE IF EXISTS public.canvas_site_mailing_lists;
+DROP TABLE IF EXISTS public.canvas_synchronization;
+DROP TABLE IF EXISTS public.user_auths;
+DROP TABLE IF EXISTS public.user_data;
+
+--

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -1,0 +1,114 @@
+/**
+ * Copyright ©2022. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET row_security = off;
+SET search_path = public, pg_catalog;
+SET default_tablespace = '';
+SET default_with_oids = false;
+
+CREATE TABLE canvas_site_mailing_list_members (
+    id SERIAL PRIMARY KEY,
+    mailing_list_id INTEGER NOT NULL,
+    email_address CHARACTER VARYING(255) NOT NULL,
+    can_send BOOLEAN DEFAULT FALSE NOT NULL,
+    first_name CHARACTER VARYING(255),
+    last_name CHARACTER VARYING(255),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    deleted_at TIMESTAMP WITH TIME ZONE,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    welcomed_at TIMESTAMP WITH TIME ZONE
+);
+ALTER TABLE ONLY canvas_site_mailing_list_members
+    ADD CONSTRAINT canvas_site_mailing_list_members_unique_constraint UNIQUE (mailing_list_id, email_address);
+CREATE INDEX canvas_site_mailing_list_members_deleted_at_idx
+    ON canvas_site_mailing_list_members USING btree (deleted_at);
+CREATE INDEX canvas_site_mailing_list_members_welcomed_at_idx
+    ON canvas_site_mailing_list_members USING btree (welcomed_at);
+
+--
+
+CREATE TABLE canvas_site_mailing_lists (
+    id SERIAL PRIMARY KEY,
+    canvas_site_id INTEGER NOT NULL,
+    canvas_site_name CHARACTER VARYING(255),
+    list_name CHARACTER VARYING(255),
+    members_count INTEGER,
+    populate_add_errors INTEGER,
+    populate_remove_errors INTEGER,
+    populated_at TIMESTAMP WITH TIME ZONE,
+    state CHARACTER VARYING(255),
+    type CHARACTER VARYING(255),
+    welcome_email_active BOOLEAN DEFAULT FALSE NOT NULL,
+    welcome_email_body TEXT,
+    welcome_email_subject TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+ALTER TABLE ONLY canvas_site_mailing_lists
+    ADD CONSTRAINT canvas_site_mailing_lists_unique_constraint UNIQUE (canvas_site_id);
+
+--
+
+CREATE TABLE canvas_synchronization (
+    id SERIAL PRIMARY KEY,
+    last_guest_user_sync TIMESTAMP WITH TIME ZONE,
+    latest_term_enrollment_csv_set TIMESTAMP WITH TIME ZONE,
+    last_enrollment_sync TIMESTAMP WITH TIME ZONE,
+    last_instructor_sync TIMESTAMP WITH TIME ZONE
+);
+
+CREATE TABLE user_auths (
+    id SERIAL PRIMARY KEY,
+    uid CHARACTER VARYING(255) NOT NULL,
+    is_superuser BOOLEAN DEFAULT FALSE NOT NULL,
+    active BOOLEAN DEFAULT FALSE NOT NULL,
+    is_canvas_whitelisted BOOLEAN DEFAULT FALSE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+ALTER TABLE ONLY user_auths ADD CONSTRAINT user_auths_unique_constraint UNIQUE (uid);
+
+--
+
+CREATE TABLE user_data (
+    id SERIAL PRIMARY KEY,
+    uid CHARACTER VARYING(255) NOT NULL,
+    preferred_name CHARACTER VARYING(255) NOT NULL,
+    first_login_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+ALTER TABLE ONLY user_data ADD CONSTRAINT user_data_unique_constraint UNIQUE (uid);
+
+--


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/CLC-8002

Time to fire up Nostromo.

![image](https://user-images.githubusercontent.com/7606442/214700405-ab5c5f55-42e4-4624-a0cd-76d0de30bde0.png)

For comparison, here is [the old schema script](https://github.com/ets-berkeley-edu/junction/blob/master/db/schema.rb).  I have excluded `oec_course_codes` and `webcast_course_site_log`. 