### PR TITLE
RIP-71, psycopg2 instead of psycopg2-binary to solve libpq?

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask==2.2.2
 Flask-Login==0.6.2
 Flask-SQLAlchemy==3.0.3
 ldap3==2.7
-psycopg2-binary==2.9.5
+psycopg2==2.9.5
 PyLTI1p3==2.0.0
 python-cas==1.6.0
 python-dateutil==2.8.2


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-71

Psycopg killer