### PR TITLE
RIP-96: makes remember cookie secure

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -77,6 +77,7 @@ LOGGING_LEVEL = logging.DEBUG
 LOGGING_PROPAGATION_LEVEL = logging.WARN
 
 REMEMBER_COOKIE_NAME = 'remember_ripley_token'
+REMEMBER_COOKIE_SECURE = True
 
 # Used to encrypt session cookie.
 SECRET_KEY = 'secret'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-96

Hoping this will resolve issue where the `remember_ripley_token` is not present when the page loads after LTI launch.  See https://stackoverflow.com/questions/60980567/flask-cookies-do-not-have-the-samesite-attribute