### PR TITLE
RIP-118, include canvas user data (eg 'roles') in user profile feed

### DIFF
--- a/ripley/api/auth_controller.py
+++ b/ripley/api/auth_controller.py
@@ -77,7 +77,7 @@ def update_user_session():
         user = User(user_id)
         if user.is_active:
             start_login_session(user)
-            return tolerant_jsonify(current_user.to_api_json())
+            return tolerant_jsonify(current_user.to_api_json(include_canvas_user_data=True))
         else:
             msg = f'Sorry, {uid} is not authorized to use this tool.'
             return tolerant_jsonify({'message': msg}, 403)

--- a/ripley/api/user_controller.py
+++ b/ripley/api/user_controller.py
@@ -31,7 +31,7 @@ from ripley.models.user import User
 
 @app.route('/api/user/my_profile')
 def my_profile():
-    return tolerant_jsonify(current_user.to_api_json())
+    return tolerant_jsonify(current_user.to_api_json(include_canvas_user_data=True))
 
 
 @app.route('/api/user/profile', methods=['POST'])
@@ -44,6 +44,6 @@ def get_user_profile():
             canvas_site_id=current_user.canvas_site_id,
             uid=uid,
         )
-        return tolerant_jsonify(User(user_id).to_api_json())
+        return tolerant_jsonify(User(user_id).to_api_json(include_canvas_user_data=True))
     else:
         raise BadRequestError('Invalid UID')

--- a/ripley/api/util.py
+++ b/ripley/api/util.py
@@ -29,7 +29,6 @@ from urllib.parse import urljoin, urlparse
 
 from flask import abort, current_app as app, redirect, request, Response
 from flask_login import current_user, login_user, logout_user
-from ripley.externals import canvas
 from ripley.lib.http import tolerant_jsonify
 from werkzeug.wrappers import ResponseStream
 
@@ -53,9 +52,9 @@ def canvas_role_required(*roles):
             if current_user.is_authenticated and current_user.is_admin:
                 authorized = True
             elif current_user.is_authenticated and current_user.canvas_user_id:
-                canvas_site_user = canvas.get_course_user(kw['canvas_site_id'], current_user.canvas_user_id)
-                if canvas_site_user and canvas_site_user.enrollments:
-                    if next((e for e in canvas_site_user.enrollments if e['role'] in roles), None):
+                canvas_site_id = str(kw['canvas_site_id'])
+                if canvas_site_id and canvas_site_id == str(current_user.canvas_site_id):
+                    if next((role for role in current_user.canvas_site_user_roles if role in roles), None):
                         authorized = True
             if authorized:
                 return func(*args, **kw)

--- a/ripley/lib/http.py
+++ b/ripley/lib/http.py
@@ -39,7 +39,13 @@ def add_param_to_url(url, param):
 def tolerant_jsonify(obj, status=200, **kwargs):
     class LazyLoadingEncoder(json.JSONEncoder):
         def default(self, value):
-            return json.JSONEncoder.encode(self, value() if callable(value) else value)
+            result = None
+            if callable(value):
+                result = value()
+                result = result if isinstance(result, dict) else json.JSONEncoder.encode(self, result)
+            else:
+                return json.JSONEncoder.encode(self, result)
+            return result
     content = json.dumps(
         obj,
         cls=LazyLoadingEncoder,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,9 +116,10 @@ class FakeAuth(object):
         self.app = the_app
         self.client = the_client
 
-    def login(self, uid):
+    def login(self, canvas_site_id, uid):
         with override_config(self.app, 'DEV_AUTH_ENABLED', True):
             params = {
+                'canvasSiteId': canvas_site_id,
                 'uid': uid,
                 'password': self.app.config['DEV_AUTH_PASSWORD'],
             }

--- a/tests/test_api/test_canvas_site_controller.py
+++ b/tests/test_api/test_canvas_site_controller.py
@@ -41,22 +41,25 @@ class TestGetRoster:
 
     def test_no_canvas_account(self, client, fake_auth):
         """Denies user with no Canvas account."""
-        fake_auth.login(no_canvas_account_uid)
-        _api_get_roster(client, '1234567', expected_status_code=401)
+        canvas_site_id = '1234567'
+        fake_auth.login(canvas_site_id=canvas_site_id, uid=no_canvas_account_uid)
+        _api_get_roster(client, canvas_site_id, expected_status_code=401)
 
     def test_not_enrolled(self, client, app, fake_auth):
         """Denies user with no course enrollment."""
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {'course': ['get_by_id'], 'user': ['profile_20000']}, m)
-            fake_auth.login(not_enrolled_uid)
-            _api_get_roster(client, '1234567', expected_status_code=401)
+            canvas_site_id = '1234567'
+            fake_auth.login(canvas_site_id=canvas_site_id, uid=not_enrolled_uid)
+            _api_get_roster(client, canvas_site_id, expected_status_code=401)
 
     def test_admin(self, client, app, fake_auth):
         """Allows admin."""
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {'course': ['get_by_id']}, m)
-            fake_auth.login(admin_uid)
-            response = _api_get_roster(client, '1234567')
+            canvas_site_id = '1234567'
+            fake_auth.login(canvas_site_id=canvas_site_id, uid=admin_uid)
+            response = _api_get_roster(client, canvas_site_id)
 
             assert response['canvasSite']['canvasSiteId'] == 1234567
             assert response['canvasSite']['name'] == 'ASTRON 218: Stellar Dynamics and Galactic Structure'
@@ -70,8 +73,9 @@ class TestGetRoster:
                 'course': ['get_by_id', 'get_user_1234567_4567890'],
                 'user': ['profile_30000'],
             }, m)
-            fake_auth.login(teacher_uid)
-            response = _api_get_roster(client, '1234567')
+            canvas_site_id = '1234567'
+            fake_auth.login(canvas_site_id=canvas_site_id, uid=teacher_uid)
+            response = _api_get_roster(client, canvas_site_id)
 
             assert response['canvasSite']['canvasSiteId'] == 1234567
             assert response['canvasSite']['name'] == 'ASTRON 218: Stellar Dynamics and Galactic Structure'
@@ -85,11 +89,12 @@ class TestGetRoster:
                 'course': ['get_by_id', 'get_user_1234567_5678901'],
                 'user': ['profile_40000'],
             }, m)
-            fake_auth.login(student_uid)
-            _api_get_roster(client, '1234567', expected_status_code=401)
+            canvas_site_id = '1234567'
+            fake_auth.login(canvas_site_id=canvas_site_id, uid=student_uid)
+            _api_get_roster(client, canvas_site_id, expected_status_code=401)
 
 
-def _api_get_roster(client, course_id, expected_status_code=200):
-    response = client.get(f'api/canvas_site/{course_id}/roster')
+def _api_get_roster(client, canvas_site_id, expected_status_code=200):
+    response = client.get(f'api/canvas_site/{canvas_site_id}/roster')
     assert response.status_code == expected_status_code
     return response.json

--- a/tests/test_api/test_job_controller.py
+++ b/tests/test_api/test_job_controller.py
@@ -42,7 +42,7 @@ class TestDisableJob:
 
     def test_unauthorized(self, client, fake_auth, mock_job):
         """Denies unauthorized user."""
-        fake_auth.login(non_admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=non_admin_uid)
         params = {
             'jobId': mock_job.id,
             'disable': True,
@@ -50,7 +50,7 @@ class TestDisableJob:
         _api_disable_job(client, params=params, expected_status_code=401)
 
     def test_authorized(self, client, fake_auth, mock_job):
-        fake_auth.login(admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=admin_uid)
         params = {
             'jobId': mock_job.id,
             'disable': True,
@@ -60,11 +60,11 @@ class TestDisableJob:
         assert response['disabled'] is True
 
     def test_empty_params(self, client, fake_auth):
-        fake_auth.login(admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=admin_uid)
         _api_disable_job(client, expected_status_code=400)
 
     def test_bad_job_id(self, client, fake_auth):
-        fake_auth.login(admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=admin_uid)
         params = {
             'jobId': 0,
             'disable': True,
@@ -90,11 +90,11 @@ class TestJobHistory:
 
     def test_unauthorized(self, client, fake_auth):
         """Denies unauthorized user."""
-        fake_auth.login(non_admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=non_admin_uid)
         _api_job_history(client, expected_status_code=401)
 
     def test_authorized(self, client, fake_auth):
-        fake_auth.login(admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=admin_uid)
         response = _api_job_history(client)
         assert response == []
 
@@ -113,11 +113,11 @@ class TestJobSchedule:
 
     def test_unauthorized(self, client, fake_auth):
         """Denies unauthorized user."""
-        fake_auth.login(non_admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=non_admin_uid)
         _api_job_schedule(client, expected_status_code=401)
 
     def test_authorized(self, client, fake_auth):
-        fake_auth.login(admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=admin_uid)
         response = _api_job_schedule(client)
         assert response['autoStart'] is False
         assert response['secondsBetweenJobsCheck'] == 0.5
@@ -147,16 +147,16 @@ class TestLastSuccessfulRun:
 
     def test_unauthorized(self, client, fake_auth):
         """Denies unauthorized user."""
-        fake_auth.login(non_admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=non_admin_uid)
         _api_last_successful_run(client, expected_status_code=401)
 
     def test_authorized(self, client, fake_auth, mock_job):
-        fake_auth.login(admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=admin_uid)
         response = _api_last_successful_run(client, job_key=mock_job.key)
         assert response is None
 
     def test_bad_job_key(self, client, fake_auth):
-        fake_auth.login(admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=admin_uid)
         response = _api_last_successful_run(client, job_key='ready to work')
         assert response is None
 
@@ -175,11 +175,11 @@ class TestStartJob:
 
     def test_unauthorized(self, client, fake_auth):
         """Denies unauthorized user."""
-        fake_auth.login(non_admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=non_admin_uid)
         _api_start_job(client, expected_status_code=401)
 
     def test_authorized(self, client, fake_auth, mock_job):
-        fake_auth.login(admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=admin_uid)
         response = _api_start_job(client, job_key=mock_job.key)
         assert response['class'] == 'TempJob'
         assert response['description'] == "I'm a mock job class"
@@ -187,7 +187,7 @@ class TestStartJob:
         assert response['name'] == 'Temp'
 
     def test_bad_job_key(self, client, fake_auth):
-        fake_auth.login(admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=admin_uid)
         _api_start_job(client, job_key='ready to work', expected_status_code=404)
 
 
@@ -209,12 +209,12 @@ class TestUpdateSchedule:
 
     def test_unauthorized(self, client, fake_auth):
         """Denies unauthorized user."""
-        fake_auth.login(non_admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=non_admin_uid)
         _api_update_schedule(client, expected_status_code=401)
 
     def test_authorized(self, client, fake_auth, mock_job):
         mock_job.disabled = True
-        fake_auth.login(admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=admin_uid)
         params = {
             'jobId': mock_job.id,
             'type': 'minutes',
@@ -230,11 +230,11 @@ class TestUpdateSchedule:
         assert response['updatedAt']
 
     def test_empty_params(self, client, fake_auth):
-        fake_auth.login(admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=admin_uid)
         _api_update_schedule(client, expected_status_code=400)
 
     def test_enabled_job(self, client, fake_auth, mock_job):
-        fake_auth.login(admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=admin_uid)
         params = {
             'jobId': mock_job.id,
             'type': 'minutes',
@@ -243,7 +243,7 @@ class TestUpdateSchedule:
         _api_update_schedule(client, params, expected_status_code=400)
 
     def test_bad_job_key(self, client, fake_auth):
-        fake_auth.login(admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=admin_uid)
         params = {
             'jobId': 0,
             'type': 'minutes',
@@ -252,7 +252,7 @@ class TestUpdateSchedule:
         _api_update_schedule(client, params, expected_status_code=400)
 
     def test_invalid_schedule(self, client, fake_auth, mock_job):
-        fake_auth.login(admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=admin_uid)
         params = {
             'jobId': mock_job.id,
             'type': 'eons',

--- a/tests/test_api/test_mailing_list_controller.py
+++ b/tests/test_api/test_mailing_list_controller.py
@@ -41,23 +41,24 @@ class TestFindMailingList:
 
     def test_no_canvas_account(self, client, fake_auth):
         """Denies user with no Canvas account."""
-        fake_auth.login(no_canvas_account_uid)
+        fake_auth.login(canvas_site_id=None, uid=no_canvas_account_uid)
         _api_find_mailing_list(client, '1234567', expected_status_code=401)
 
     def test_not_enrolled(self, client, app, fake_auth):
         """Denies user with no course enrollment."""
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {'course': ['get_by_id'], 'user': ['profile_20000']}, m)
-            fake_auth.login(not_enrolled_uid)
+            fake_auth.login(canvas_site_id=None, uid=not_enrolled_uid)
             _api_find_mailing_list(client, '1234567', expected_status_code=401)
 
     def test_admin(self, client, app, fake_auth):
         """Allows admin."""
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {'course': ['get_by_id']}, m)
-            fake_auth.login(admin_uid)
-            _api_create_mailing_list(client, '1234567')
-            response = _api_find_mailing_list(client, '1234567')
+            canvas_site_id = '1234567'
+            fake_auth.login(canvas_site_id=canvas_site_id, uid=admin_uid)
+            _api_create_mailing_list(client, canvas_site_id)
+            response = _api_find_mailing_list(client, canvas_site_id)
 
             assert response['canvasSite']['canvasSiteId'] == 1234567
             assert response['canvasSite']['name'] == 'ASTRON 218: Stellar Dynamics and Galactic Structure'
@@ -70,9 +71,10 @@ class TestFindMailingList:
                 'course': ['get_by_id', 'get_user_1234567_4567890'],
                 'user': ['profile_30000'],
             }, m)
-            fake_auth.login(teacher_uid)
-            _api_create_mailing_list(client, '1234567')
-            response = _api_find_mailing_list(client, '1234567')
+            canvas_site_id = '1234567'
+            fake_auth.login(canvas_site_id=canvas_site_id, uid=teacher_uid)
+            _api_create_mailing_list(client, canvas_site_id)
+            response = _api_find_mailing_list(client, canvas_site_id)
 
             assert response['name'] == 'astron-218-stellar-dynamics-and-galactic-stru-sp23'
 
@@ -83,12 +85,13 @@ class TestFindMailingList:
                 'course': ['get_by_id', 'get_user_1234567_5678901'],
                 'user': ['profile_40000'],
             }, m)
-            fake_auth.login(student_uid)
-            _api_find_mailing_list(client, '1234567', expected_status_code=401)
+            canvas_site_id = '1234567'
+            fake_auth.login(canvas_site_id=canvas_site_id, uid=student_uid)
+            _api_find_mailing_list(client, canvas_site_id, expected_status_code=401)
 
 
-def _api_find_mailing_list(client, course_id, expected_status_code=200):
-    response = client.get(f'api/mailing_lists/{course_id}')
+def _api_find_mailing_list(client, canvas_site_id, expected_status_code=200):
+    response = client.get(f'api/mailing_lists/{canvas_site_id}')
     assert response.status_code == expected_status_code
     return response.json
 
@@ -101,29 +104,32 @@ class TestCreateMailingList:
 
     def test_no_canvas_account(self, client, fake_auth):
         """Denies user with no Canvas account."""
-        fake_auth.login(no_canvas_account_uid)
-        _api_create_mailing_list(client, '1234567', expected_status_code=401)
+        canvas_site_id = '1234567'
+        fake_auth.login(canvas_site_id=canvas_site_id, uid=no_canvas_account_uid)
+        _api_create_mailing_list(client, canvas_site_id, expected_status_code=401)
 
     def test_not_enrolled(self, client, app, fake_auth):
         """Denies user with no course enrollment."""
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {'course': ['get_by_id'], 'user': ['profile_20000']}, m)
-            fake_auth.login(not_enrolled_uid)
-            _api_create_mailing_list(client, '1234567', expected_status_code=401)
+            canvas_site_id = '1234567'
+            fake_auth.login(canvas_site_id=canvas_site_id, uid=not_enrolled_uid)
+            _api_create_mailing_list(client, canvas_site_id, expected_status_code=401)
 
     def test_admin(self, client, app, fake_auth):
         """Allows admin."""
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {'course': ['get_by_id']}, m)
-            fake_auth.login(admin_uid)
-            response = _api_create_mailing_list(client, '1234567')
+            canvas_site_id = '1234567'
+            fake_auth.login(canvas_site_id=canvas_site_id, uid=admin_uid)
+            response = _api_create_mailing_list(client, canvas_site_id)
 
             assert response['canvasSite']['canvasSiteId'] == 1234567
             assert response['canvasSite']['name'] == 'ASTRON 218: Stellar Dynamics and Galactic Structure'
             assert response['name'] == 'astron-218-stellar-dynamics-and-galactic-stru-sp23'
 
             # But you can't step into the same mailing list twice.
-            _api_create_mailing_list(client, '1234567', expected_status_code=400)
+            _api_create_mailing_list(client, canvas_site_id, expected_status_code=400)
 
     def test_teacher(self, client, app, fake_auth):
         """Allows teacher."""
@@ -132,8 +138,9 @@ class TestCreateMailingList:
                 'course': ['get_by_id', 'get_user_1234567_4567890'],
                 'user': ['profile_30000'],
             }, m)
-            fake_auth.login(teacher_uid)
-            response = _api_create_mailing_list(client, '1234567')
+            canvas_site_id = '1234567'
+            fake_auth.login(canvas_site_id=canvas_site_id, uid=teacher_uid)
+            response = _api_create_mailing_list(client, canvas_site_id)
 
             assert response['name'] == 'astron-218-stellar-dynamics-and-galactic-stru-sp23'
 
@@ -144,8 +151,9 @@ class TestCreateMailingList:
                 'course': ['get_by_id', 'get_user_1234567_5678901'],
                 'user': ['profile_40000'],
             }, m)
-            fake_auth.login(student_uid)
-            _api_create_mailing_list(client, '1234567', expected_status_code=401)
+            canvas_site_id = '1234567'
+            fake_auth.login(canvas_site_id=canvas_site_id, uid=student_uid)
+            _api_create_mailing_list(client, canvas_site_id, expected_status_code=401)
 
 
 class TestPopulateMailingList:
@@ -156,23 +164,26 @@ class TestPopulateMailingList:
 
     def test_no_canvas_account(self, client, fake_auth):
         """Denies user with no Canvas account."""
-        fake_auth.login(no_canvas_account_uid)
-        _api_populate_mailing_list(client, '1234567', expected_status_code=401)
+        canvas_site_id = '1234567'
+        fake_auth.login(canvas_site_id=canvas_site_id, uid=no_canvas_account_uid)
+        _api_populate_mailing_list(client, canvas_site_id, expected_status_code=401)
 
     def test_not_enrolled(self, client, app, fake_auth):
         """Denies user with no course enrollment."""
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {'course': ['get_by_id'], 'user': ['profile_20000']}, m)
-            fake_auth.login(not_enrolled_uid)
-            _api_populate_mailing_list(client, '1234567', expected_status_code=401)
+            canvas_site_id = '1234567'
+            fake_auth.login(canvas_site_id=canvas_site_id, uid=not_enrolled_uid)
+            _api_populate_mailing_list(client, canvas_site_id, expected_status_code=401)
 
     def test_admin(self, client, app, fake_auth):
         """Allows admin."""
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {'course': ['get_by_id', 'search_users_1234567', 'user_profile_10000']}, m)
-            fake_auth.login(admin_uid)
-            _api_create_mailing_list(client, '1234567')
-            api_json = _api_populate_mailing_list(client, '1234567')
+            canvas_site_id = '1234567'
+            fake_auth.login(canvas_site_id=canvas_site_id, uid=admin_uid)
+            _api_create_mailing_list(client, canvas_site_id)
+            api_json = _api_populate_mailing_list(client, canvas_site_id)
             assert api_json['mailingList']['canvasSite']['canvasSiteId'] == 1234567
             # TODO: verify populated mailing list
 
@@ -183,9 +194,10 @@ class TestPopulateMailingList:
                 'course': ['get_by_id', 'get_user_1234567_4567890', 'search_users_1234567'],
                 'user': ['profile_30000'],
             }, m)
-            fake_auth.login(teacher_uid)
-            _api_create_mailing_list(client, '1234567')
-            api_json = _api_populate_mailing_list(client, '1234567')
+            canvas_site_id = '1234567'
+            fake_auth.login(canvas_site_id=canvas_site_id, uid=teacher_uid)
+            _api_create_mailing_list(client, canvas_site_id)
+            api_json = _api_populate_mailing_list(client, canvas_site_id)
             assert api_json['mailingList']['name'] == 'astron-218-stellar-dynamics-and-galactic-stru-sp23'
             # TODO: verify populated mailing list
 
@@ -196,18 +208,19 @@ class TestPopulateMailingList:
                 'course': ['get_by_id', 'get_user_1234567_5678901'],
                 'user': ['profile_40000'],
             }, m)
-            fake_auth.login(student_uid)
-            _api_populate_mailing_list(client, '1234567', expected_status_code=401)
+            canvas_site_id = '1234567'
+            fake_auth.login(canvas_site_id=canvas_site_id, uid=student_uid)
+            _api_populate_mailing_list(client, canvas_site_id, expected_status_code=401)
 
 
-def _api_create_mailing_list(client, course_id, expected_status_code=200):
-    response = client.post(f'/api/mailing_lists/{course_id}/create')
+def _api_create_mailing_list(client, canvas_site_id, expected_status_code=200):
+    response = client.post(f'/api/mailing_lists/{canvas_site_id}/create')
     assert response.status_code == expected_status_code
     return response.json
 
 
-def _api_populate_mailing_list(client, course_id, expected_status_code=200):
-    response = client.post(f'/api/mailing_lists/{course_id}/populate')
+def _api_populate_mailing_list(client, canvas_site_id, expected_status_code=200):
+    response = client.post(f'/api/mailing_lists/{canvas_site_id}/populate')
     api_json = response.json
     assert response.status_code == expected_status_code, f"""
         HTTP status code {response.status_code} != {expected_status_code}

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -51,16 +51,16 @@ class TestUserProfile:
 
     def test_unauthorized(self, client, fake_auth):
         """Denies unauthorized user."""
-        fake_auth.login(teacher_uid)
+        fake_auth.login(canvas_site_id=1234567, uid=teacher_uid)
         self._api_user_profile(client, expected_status_code=400, uid=student_uid)
 
     def test_user_can_view_own_profile(self, client, fake_auth):
         """User can view own profile."""
-        fake_auth.login(student_uid)
+        fake_auth.login(canvas_site_id=1234567, uid=student_uid)
         self._api_user_profile(client, uid=student_uid)
 
     def test_authorized_admin(self, client, fake_auth):
-        fake_auth.login(admin_uid)
+        fake_auth.login(canvas_site_id=None, uid=admin_uid)
         api_json = self._api_user_profile(client, uid=student_uid)
         assert api_json['uid'] == student_uid
 
@@ -68,7 +68,8 @@ class TestUserProfile:
         """Masquerading user gets profile of masqueradee."""
         from flask_login import current_user
 
-        fake_auth.login(teacher_uid)
+        canvas_site_id = 1234567
+        fake_auth.login(canvas_site_id=canvas_site_id, uid=teacher_uid)
         assert current_user.uid == teacher_uid
         response = client.get('/api/user/my_profile')
         assert response.json['uid'] == teacher_uid
@@ -76,11 +77,11 @@ class TestUserProfile:
         user_sessions = [c for c in cookies if 'remember_ripley_token' in c]
         assert len(user_sessions) == 1
         user_session = parse_cookie(user_sessions[0])
-        assert '{"canvas_site_id": null, "uid": "30000"}' in user_session['remember_ripley_token']
+        assert '{"canvas_site_id": 1234567, "uid": "30000"}' in user_session['remember_ripley_token']
         assert 'Secure' in user_session
         assert user_session['SameSite'] == 'None'
 
-        fake_auth.login(student_uid)
+        fake_auth.login(canvas_site_id=canvas_site_id, uid=student_uid)
         assert current_user.uid == student_uid
         response = client.get('/api/user/my_profile')
         assert response.json['uid'] == student_uid
@@ -88,6 +89,6 @@ class TestUserProfile:
         user_sessions = [c for c in cookies if 'remember_ripley_token' in c]
         assert len(user_sessions) == 1
         user_session = parse_cookie(user_sessions[0])
-        assert '{"canvas_site_id": null, "uid": "40000"}' in user_session['remember_ripley_token']
+        assert '{"canvas_site_id": 1234567, "uid": "40000"}' in user_session['remember_ripley_token']
         assert 'Secure' in user_session
         assert user_session['SameSite'] == 'None'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-118

And `canvas_site_id` is added to `fake_auth.login` in tests.