### PR TITLE
RIP-109, add per_page arg (pagination) to Canvas API call

### DIFF
--- a/ripley/externals/canvas.py
+++ b/ripley/externals/canvas.py
@@ -72,9 +72,13 @@ def get_course(course_id, api_call=True):
         return course
 
 
-def get_course_students(course_id):
+def get_course_students(course_id, per_page=10):
     try:
-        return get_course(course_id, api_call=False).get_users(enrollment_type=['student'], include=['enrollments'])
+        return get_course(course_id, api_call=False).get_users(
+            enrollment_type=['student'],
+            include=['enrollments'],
+            per_page=per_page,
+        )
     except Exception as e:
         app.logger.error(f'Failed to retrieve Canvas course students (course_id={course_id})')
         app.logger.exception(e)

--- a/src/components/bcourses/roster/RosterPhoto.vue
+++ b/src/components/bcourses/roster/RosterPhoto.vue
@@ -32,8 +32,9 @@ export default {
     photoUrl: undefined
   }),
   created() {
-    if (this.student.photo) {
-      this.photoUrl = this.config.apiBaseUrl ? `${this.config.apiBaseUrl}${this.student.photo}` : this.student.photo
+    const photoUrl = this.$_.trim(this.student.photoUrl || '')
+    if (photoUrl) {
+      this.photoUrl = photoUrl.startsWith('http') ? photoUrl : `${this.config.apiBaseUrl}${photoUrl}`
     } else {
       this.imageError()
     }

--- a/tests/test_api/test_canvas_site_controller.py
+++ b/tests/test_api/test_canvas_site_controller.py
@@ -64,8 +64,6 @@ class TestGetRoster:
             fake_auth.login(canvas_site_id=canvas_site_id, uid=admin_uid)
             response = _api_get_roster(client, canvas_site_id)
 
-            assert response['canvasSite']['canvasSiteId'] == 8876542
-            assert response['canvasSite']['name'] == 'Our Dogs, Ourselves: Encounters between the Human and the Non-Human'
             assert len(response['sections']) == 1
             section = response['sections'][0]
             assert section['id'] == 'SEC:2023-B-32936'
@@ -76,14 +74,10 @@ class TestGetRoster:
             assert student['email'] == 'xo.kane@berkeley.edu'
             assert student['enrollStatus'] == 'active'
             assert student['firstName'] == 'XO'
-            assert student['gradeOption'] == 'TODO'
             assert student['id'] == 5678901
             assert student['lastName'] == 'Kane'
             assert student['loginId'] == '40000'
-            assert student['photoUrl'] == 'TODO'
-            assert student['sectionIds'] == 'TODO'
             assert student['studentId'] == 'UID:40000'
-            assert student['units'] == 'TODO'
             assert len(student['sections'])
             assert student['sections'][0]['id'] == 'SEC:2023-B-32936'
             assert student['sections'][0]['name'] == 'Section A'
@@ -98,12 +92,9 @@ class TestGetRoster:
             }, m)
             canvas_site_id = '8876542'
             fake_auth.login(canvas_site_id=canvas_site_id, uid=teacher_uid)
-            response = _api_get_roster(client, canvas_site_id)
-
-            assert response['canvasSite']['canvasSiteId'] == 8876542
-            assert response['canvasSite']['name'] == 'Our Dogs, Ourselves: Encounters between the Human and the Non-Human'
-            assert len(response['sections']) == 1
-            assert len(response['students']) == 1
+            api_json = _api_get_roster(client, canvas_site_id)
+            assert len(api_json['sections']) == 1
+            assert len(api_json['students']) == 1
 
     def test_student(self, client, app, fake_auth):
         """Denies student."""


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-109

A little performance bump.  I removed `canvasSite` from the `/rosters` response because I don't think we need it and it lessens the overhead of the feed. Let me know if that's a wrong turn. cc: @lyttam 