### PR TITLE
RIP-128, Ripley moves to Python 3.9 per Codebuild 4.0 spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
 language: python
-python: "3.8"
+python: "3.9"
 
 addons:
   postgresql: "9.6"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ripley heroically supports UC Berkeley's Canvas LMS instance.
 
 ## Installation
 
-* Install Python 3.8
+* Install Python 3.9
 * Create your virtual environment (venv)
 * Install dependencies
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ phases:
   install:
     runtime-versions:
       nodejs: 12
-      python: 3.8
+      python: 3.9
     commands:
       - n 16  # Force Node update to v16
       - npm -v


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-128

Because Codebuild's `Amazon Linux 2 AArch64 standard:2.0` image does not support Python 3.8.