### PR TITLE
RIP-218 Secure attributes for Flask session cookie

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -114,6 +114,10 @@ REDIS_PORT = '6379'
 # Used to encrypt session cookie.
 SECRET_KEY = 'secret'
 
+# Preserve flask-login session inside iframes.
+SESSION_COOKIE_SAMESITE = 'None'
+SESSION_COOKIE_SECURE = True
+
 # Override in local configs.
 SQLALCHEMY_DATABASE_URI = 'postgresql://ripley:ripley@localhost:5432/nostromo'
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-218

Our current auth scheme (which frankly might need rethinking) involves two separate cookies, the session cookie that flask-login gives us for free, plus a separate custom Ripley token. We had security attributes set on the latter but not the former, causing login trouble in Chrome.