### PR TITLE
RIP-263 Tighten users query for bCourses refresh

### DIFF
--- a/ripley/externals/data_loch.py
+++ b/ripley/externals/data_loch.py
@@ -90,7 +90,8 @@ def get_users(uids=None):
         SELECT * FROM sis_data.{_basic_attributes_table()}
         WHERE {uids_sql_fragment} (
             person_type != 'A' OR
-            affiliations LIKE '%STUDENT-TYPE%' OR
+            affiliations LIKE '%STUDENT-TYPE-REGISTERED%' OR
+            affiliations LIKE '%STUDENT-TYPE-NOT REGISTERED%' OR
             affiliations LIKE '%EMPLOYEE-TYPE%' OR
             affiliations LIKE '%GUEST-TYPE%'
         )


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-263

The specific leak we want to plug involves person_type `A` and affiliation `STUDENT-TYPE-PRESIR`.