### PR TITLE
RIP-319, prepare_egrade_export in background_job; remove redis caching in canvas.get_course

### DIFF
--- a/ripley/api/canvas_site_controller.py
+++ b/ripley/api/canvas_site_controller.py
@@ -190,7 +190,7 @@ def egrade_export_prepare(canvas_site_id):
     course = canvas.get_course(canvas_site_id)
     if not course:
         raise ResourceNotFoundError(f'No Canvas course site found with ID {canvas_site_id}')
-    job = enqueue(func=prepare_egrade_export, args=(course))
+    job = enqueue(func=prepare_egrade_export, args=canvas_site_id)
     if not job:
         raise InternalServerError('Updates cannot be completed at this time.')
     return tolerant_jsonify(

--- a/ripley/externals/canvas.py
+++ b/ripley/externals/canvas.py
@@ -35,7 +35,6 @@ from canvasapi.section import Section
 from canvasapi.sis_import import SisImport
 from canvasapi.user import User
 from flask import current_app as app
-from ripley.externals.redis import cache_dict_object, fetch_cached_dict_object
 
 # By default, we allow up to an hour for Canvas to rouse itself.
 BACKGROUND_STATUS_CHECK_INTERVAL = 20
@@ -86,17 +85,12 @@ def get_course(course_id, api_call=True):
     if api_call is False:
         return Course(c._Canvas__requester, {'id': course_id})
     else:
-        cache_key = f'canvas_course_{course_id}'
-        course = fetch_cached_dict_object(cache_key)
-        if not course:
-            try:
-                course = c.get_course(course_id, include=['term'])
-                if course:
-                    cache_dict_object(cache_key, course, 120)
-            except Exception as e:
-                app.logger.error(f'Failed to retrieve Canvas course (id={course_id})')
-                app.logger.exception(e)
-        return course
+        try:
+            course = c.get_course(course_id, include=['term'])
+        except Exception as e:
+            app.logger.error(f'Failed to retrieve Canvas course (id={course_id})')
+            app.logger.exception(e)
+    return course
 
 
 def get_course_sections(course_id):

--- a/ripley/externals/redis.py
+++ b/ripley/externals/redis.py
@@ -28,6 +28,7 @@ from fakeredis import FakeStrictRedis
 from flask import current_app as app
 import redis
 from ripley import skip_when_pytest
+from ripley.api.errors import InternalServerError
 from rq import Connection, Queue, Worker
 from rq.job import Job, Retry
 
@@ -37,10 +38,13 @@ redis_conn = None
 
 @skip_when_pytest()
 def cache_dict_object(cache_key, dict_object, expire_seconds=None):
-    get_redis_conn(app)
-    redis_conn.set(cache_key, json.dumps(dict_object))
-    if expire_seconds:
-        redis_conn.expire(cache_key, time=expire_seconds)
+    if type(dict_object) is dict:
+        get_redis_conn(app)
+        redis_conn.set(cache_key, json.dumps(dict_object))
+        if expire_seconds:
+            redis_conn.expire(cache_key, time=expire_seconds)
+    else:
+        raise InternalServerError(f'Invalid object type: {type(dict_object)}')
 
 
 @skip_when_pytest()


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-319

The `course` object we get from canvas (external) is not always serializable. 