### PR TITLE
RIP-329 Adjust session key for Canvas masquerade id

### DIFF
--- a/ripley/api/auth_controller.py
+++ b/ripley/api/auth_controller.py
@@ -74,13 +74,13 @@ def update_user_session():
         params = request.get_json() or {}
         canvas_site_id = params.get('canvasSiteId')
         uid = current_user.uid
-        acting_as_uid = current_user.acting_as_uid
+        canvas_masquerading_user_id = current_user.canvas_masquerading_user_id
         logout_user()
         # Re-authenticate
         user_id = User.get_serialized_composite_key(
             canvas_site_id=canvas_site_id,
             uid=uid,
-            acting_as_uid=acting_as_uid,
+            canvas_masquerading_user_id=canvas_masquerading_user_id,
         )
         user = User(user_id)
         if start_login_session(user) and (user.is_admin or len(user.canvas_site_user_roles)):

--- a/ripley/api/canvas_site_controller.py
+++ b/ripley/api/canvas_site_controller.py
@@ -321,8 +321,8 @@ def _get_teaching_terms(section_ids, sections):
             terms.append(term)
 
     teaching_sections = []
-    if (current_user.is_teaching or current_user.acting_as_uid):
-        instructor_uid = current_user.acting_as_uid or current_user.uid
+    if (current_user.is_teaching or current_user.canvas_masquerading_user_id):
+        instructor_uid = current_user.uid
         teaching_sections = sort_course_sections(
             data_loch.get_instructing_sections(instructor_uid, [t.to_sis_term_id() for t in terms]) or [],
         )

--- a/ripley/api/lti_controller.py
+++ b/ripley/api/lti_controller.py
@@ -251,7 +251,7 @@ def _launch_tool(target_uri):
         user_id = User.get_serialized_composite_key(
             canvas_site_id=canvas_site_id,
             uid=uid,
-            acting_as_uid=canvas_masquerading_user_id,
+            canvas_masquerading_user_id=canvas_masquerading_user_id,
         )
         user = User(user_id)
         if start_login_session(user):

--- a/ripley/api/user_controller.py
+++ b/ripley/api/user_controller.py
@@ -43,7 +43,7 @@ def get_user_profile():
         user_id = User.get_serialized_composite_key(
             canvas_site_id=current_user.canvas_site_id,
             uid=uid,
-            acting_as_uid=current_user.acting_as_uid,
+            canvas_masquerading_user_id=current_user.canvas_masquerading_user_id,
         )
         return tolerant_jsonify(User(user_id).to_api_json())
     else:

--- a/ripley/models/user.py
+++ b/ripley/models/user.py
@@ -47,12 +47,12 @@ class User(UserMixin):
                 self.uid = None
         canvas_site_id = str(composite_key.get('canvas_site_id', None)).strip()
         self.__canvas_site_id = int(canvas_site_id) if canvas_site_id and canvas_site_id.isnumeric() else None
-        self.__acting_as_uid = composite_key.get('acting_as_uid', None)
+        self.__canvas_masquerading_user_id = composite_key.get('canvas_masquerading_user_id', None)
         self.user = self._load_user(canvas_user_profile)
 
     def __repr__(self):
         return f"""<User
-                    acting_as_uid={self.__acting_as_uid},
+                    canvas_masquerading_user_id={self.__canvas_masquerading_user_id},
                     canvas_site_id={self.user['canvasSiteId']},
                     email_address={self.email_address},
                     is_active={self.is_active},
@@ -63,8 +63,8 @@ class User(UserMixin):
                 """
 
     @property
-    def acting_as_uid(self):
-        return self.__acting_as_uid
+    def canvas_masquerading_user_id(self):
+        return self.__canvas_masquerading_user_id
 
     @property
     def canvas_site_id(self):
@@ -82,7 +82,7 @@ class User(UserMixin):
         return self.get_serialized_composite_key(
             canvas_site_id=self.canvas_site_id,
             uid=self.uid,
-            acting_as_uid=self.acting_as_uid,
+            canvas_masquerading_user_id=self.canvas_masquerading_user_id,
         )
 
     @property
@@ -154,11 +154,11 @@ class User(UserMixin):
         return has_instructor_history(self.uid, current_term_ids)
 
     @classmethod
-    def get_serialized_composite_key(cls, canvas_site_id, uid, acting_as_uid=None):
+    def get_serialized_composite_key(cls, canvas_site_id, uid, canvas_masquerading_user_id=None):
         return json.dumps({
             'canvas_site_id': canvas_site_id,
             'uid': uid,
-            'acting_as_uid': acting_as_uid,
+            'canvas_masquerading_user_id': canvas_masquerading_user_id,
         })
 
     def _load_canvas_user_data(self, user_profile=None):
@@ -235,7 +235,7 @@ class User(UserMixin):
                     is_teaching = bool(canvas_user_data and canvas_user_data['isTeaching'])
         api_json = {
             **{
-                'canvasActingAsUid': self.__acting_as_uid,
+                'canvasMasqueradingUserId': self.__canvas_masquerading_user_id,
                 'canvasSiteId': self.__canvas_site_id,
                 'emailAddress': email_address,
                 'isActive': is_active,

--- a/ripley/routes.py
+++ b/ripley/routes.py
@@ -136,13 +136,13 @@ def _set_session(response):
         cookie_value = request.cookies[cookie_name]
         composite_key = json.loads(cookie_value.split('|')[0])
         current_user_key = current_user.get_serialized_composite_key(
-            acting_as_uid=current_user.acting_as_uid,
+            canvas_masquerading_user_id=current_user.canvas_masquerading_user_id,
             canvas_site_id=current_user.canvas_site_id,
             uid=current_user.uid,
         )
         if composite_key['uid'] == current_user.uid \
                 and composite_key['canvas_site_id'] == current_user.canvas_site_id \
-                and composite_key['acting_as_uid'] == current_user.acting_as_uid:
+                and composite_key['canvas_masquerading_user_id'] == current_user.canvas_masquerading_user_id:
             _set_cookie(response, cookie_name, cookie_value)
         elif current_user.is_authenticated:
             _set_cookie(response, cookie_name, current_user_key)
@@ -164,10 +164,10 @@ def _user_loader(user_id=None):
         if isinstance(composite_key, dict):
             canvas_site_id = composite_key.get('canvas_site_id', None)
             uid = composite_key.get('uid', None)
-            acting_as_uid = composite_key.get('acting_as_uid', None)
+            canvas_masquerading_user_id = composite_key.get('canvas_masquerading_user_id', None)
             serialized_composite_key = User.get_serialized_composite_key(
                 canvas_site_id=canvas_site_id,
                 uid=uid,
-                acting_as_uid=acting_as_uid,
+                canvas_masquerading_user_id=canvas_masquerading_user_id,
             )
     return User(serialized_composite_key)

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -119,7 +119,7 @@ class TestUserProfile:
             user_sessions = [c for c in cookies if 'remember_ripley_token' in c]
             assert len(user_sessions) == 1
             user_session = parse_cookie(user_sessions[0])
-            assert '{"canvas_site_id": 1234567, "uid": "30000", "acting_as_uid": null}' in user_session['remember_ripley_token']
+            assert '{"canvas_site_id": 1234567, "uid": "30000", "canvas_masquerading_user_id": null}' in user_session['remember_ripley_token']
             assert 'Secure' in user_session
             assert user_session['SameSite'] == 'None'
 
@@ -140,6 +140,6 @@ class TestUserProfile:
             user_sessions = [c for c in cookies if 'remember_ripley_token' in c]
             assert len(user_sessions) == 1
             user_session = parse_cookie(user_sessions[0])
-            assert '{"canvas_site_id": 1234567, "uid": "40000", "acting_as_uid": null}' in user_session['remember_ripley_token']
+            assert '{"canvas_site_id": 1234567, "uid": "40000", "canvas_masquerading_user_id": null}' in user_session['remember_ripley_token']
             assert 'Secure' in user_session
             assert user_session['SameSite'] == 'None'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-329

Our `acting_as_uid` session value was confusingly named. It's not a UID but a Canvas id, and it indicates not the person being acted as but the person doing the acting. This makes it easy to misinterpret in code; let's call it something else.