### PR TITLE
RIP-335, canvas_site_mailing_lists table gets a new column: term_id

### DIFF
--- a/ripley/lib/canvas_utils.py
+++ b/ripley/lib/canvas_utils.py
@@ -102,6 +102,12 @@ def csv_row_for_campus_user(user):
     }
 
 
+def extract_berkeley_term_id(canvas_site):
+    sis_term_id = canvas_site.term['sis_term_id']
+    term = BerkeleyTerm.from_canvas_sis_term_id(sis_term_id) if sis_term_id else None
+    return term.to_sis_term_id() if term else None
+
+
 def format_term_enrollments_export(term_id):
     return f"{term_id.replace(':', '-')}-term-enrollments-export"
 

--- a/scripts/db/migrate/20230816-RIP-335/term_id_for_canvas_site_mailing_lists.sql
+++ b/scripts/db/migrate/20230816-RIP-335/term_id_for_canvas_site_mailing_lists.sql
@@ -1,0 +1,30 @@
+/**
+ * Copyright ©2023. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+BEGIN;
+
+ALTER TABLE canvas_site_mailing_lists ADD COLUMN term_id INTEGER;
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -76,6 +76,7 @@ CREATE TABLE canvas_site_mailing_lists (
     populate_remove_errors INTEGER,
     populated_at TIMESTAMP WITH TIME ZONE,
     state CHARACTER VARYING(255),
+    term_id INTEGER,
     type CHARACTER VARYING(255),
     welcome_email_active BOOLEAN DEFAULT FALSE NOT NULL,
     welcome_email_body TEXT,

--- a/tests/test_api/test_mailing_list_controller.py
+++ b/tests/test_api/test_mailing_list_controller.py
@@ -25,6 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 import json
 
 import requests_mock
+from ripley.externals import canvas
 from ripley.models.mailing_list import MailingList
 from tests.util import register_canvas_uris
 
@@ -319,8 +320,9 @@ class TestActivateMailingList:
                 'user': ['profile_30000'],
             }, m)
             fake_auth.login(canvas_site_id=canvas_site_id, uid=admin_uid)
+            canvas_site = canvas.get_course(canvas_site_id)
             mailing_list = MailingList.create(
-                canvas_site_id=canvas_site_id,
+                canvas_site=canvas_site,
                 list_name='Wonder Twin powers activate!',
                 welcome_email_body='Body',
                 welcome_email_subject='Subject',
@@ -360,7 +362,8 @@ class TestPopulateMailingList:
                 {'course': [f'get_by_id_{canvas_site_id}'], 'user': [f'profile_{uid_of_student}']},
                 m,
             )
-            mailing_list = MailingList.create(canvas_site_id=canvas_site_id)
+            canvas_site = canvas.get_course(canvas_site_id)
+            mailing_list = MailingList.create(canvas_site)
             fake_auth.login(canvas_site_id=canvas_site_id, uid=uid_of_student)
             _api_populate_mailing_list(client, mailing_list_id=mailing_list.id, expected_status_code=401)
 
@@ -408,7 +411,8 @@ class TestPopulateMailingList:
                 'course': [f'get_by_id_{canvas_site_id}', f'get_user_{canvas_site_id}_5678901'],
                 'user': [f'profile_{student_uid}'],
             }, m)
-            mailing_list = MailingList.create(canvas_site_id=canvas_site_id)
+            canvas_site = canvas.get_course(canvas_site_id)
+            mailing_list = MailingList.create(canvas_site)
             fake_auth.login(canvas_site_id=canvas_site_id, uid=student_uid)
             _api_populate_mailing_list(client, expected_status_code=401, mailing_list_id=mailing_list.id)
 

--- a/tests/test_jobs/test_mailing_list_refresh_job.py
+++ b/tests/test_jobs/test_mailing_list_refresh_job.py
@@ -24,6 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 import requests_mock
+from ripley.externals import canvas
 from ripley.jobs.mailing_list_refresh_job import MailingListRefreshJob
 from ripley.models.mailing_list import MailingList
 from ripley.models.mailing_list_members import MailingListMembers
@@ -35,7 +36,8 @@ class TestMailingListRefreshJob:
     def test_job_run(self, app):
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {'course': ['get_by_id_1234567', 'search_users_1234567']}, m)
-            mailing_list = MailingList.create('1234567')
+            canvas_site = canvas.get_course('1234567')
+            mailing_list = MailingList.create(canvas_site)
             assert mailing_list.populated_at is None
             assert len(MailingListMembers.query.filter_by(mailing_list_id=mailing_list.id).all()) == 0
 

--- a/tests/test_models/test_mailing_list.py
+++ b/tests/test_models/test_mailing_list.py
@@ -25,6 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 import pytest
 import requests_mock
+from ripley.externals import canvas
 from ripley.models.mailing_list import MailingList
 from tests.util import register_canvas_uris
 
@@ -34,9 +35,9 @@ class TestMailingList:
     def test_initialize(self, app):
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {'course': ['get_by_id_1234567']}, m)
-            mailing_list = MailingList.create('1234567')
+            canvas_site = canvas.get_course('1234567')
+            mailing_list = MailingList.create(canvas_site)
             feed = mailing_list.to_api_json()
-
             assert feed['canvasSite']['canvasSiteId'] == 1234567
             assert feed['canvasSite']['sisCourseId'] == 'CRS:ASTRON-218-2023-B'
             assert feed['canvasSite']['name'] == 'ASTRON 218: Stellar Dynamics and Galactic Structure'
@@ -45,6 +46,7 @@ class TestMailingList:
             assert feed['canvasSite']['term'] == {'term_yr': '2023', 'term_cd': 'B', 'name': 'Spring 2023'}
 
             assert feed['name'] == 'astron-218-stellar-dynamics-and-galactic-stru-sp23'
+            assert feed['termId'] == 2232
             assert feed['welcomeEmailActive'] is False
             assert feed['welcomeEmailBody'] is None
             assert feed['welcomeEmailSubject'] is None
@@ -52,12 +54,12 @@ class TestMailingList:
     def test_create(self, app):
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {'course': ['get_by_id_1234567']}, m)
-
-            mailing_list = MailingList.create('1234567')
+            canvas_site = canvas.get_course('1234567')
+            mailing_list = MailingList.create(canvas_site)
             feed = mailing_list.to_api_json()
 
             assert feed['canvasSite']['name'] == 'ASTRON 218: Stellar Dynamics and Galactic Structure'
             assert feed['name'] == 'astron-218-stellar-dynamics-and-galactic-stru-sp23'
 
             with pytest.raises(ValueError, match='List with id 1234567 already exists'):
-                mailing_list = MailingList.create('1234567')
+                mailing_list = MailingList.create(canvas_site)


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-335

Release instructions updated: https://docs.google.com/document/d/1bQw8kI4_hPUOubkbvcu10RJw_-Ag_MEL9nu6XgcyVW4/edit

The next PR will ditch the regex in `mailing_list_job`.