### PR TITLE
RIP-335, mailing_list_refresh_job populates according to term_id

### DIFF
--- a/ripley/externals/canvas.py
+++ b/ripley/externals/canvas.py
@@ -86,11 +86,11 @@ def get_course(course_id, api_call=True):
         return Course(c._Canvas__requester, {'id': course_id})
     else:
         try:
-            course = c.get_course(course_id, include=['term'])
+            return c.get_course(course_id, include=['term'])
         except Exception as e:
             app.logger.error(f'Failed to retrieve Canvas course (id={course_id})')
             app.logger.exception(e)
-    return course
+            return None
 
 
 def get_course_sections(course_id):

--- a/ripley/lib/berkeley_term.py
+++ b/ripley/lib/berkeley_term.py
@@ -99,6 +99,15 @@ class BerkeleyTerm:
             season = chr(ord(self.season) + 1)
         return type(self)(year, season)
 
+    def previous_term(self):
+        if self.season == 'B':
+            year = str(int(self.year) - 1)
+            season = 'D'
+        else:
+            year = self.year
+            season = chr(ord(self.season) - 1)
+        return type(self)(year, season)
+
     def to_abbreviation(self):
         season_map = {
             'A': 'wi',

--- a/ripley/models/mailing_list.py
+++ b/ripley/models/mailing_list.py
@@ -115,7 +115,7 @@ class MailingList(Base):
             raise ValueError(f'The name {list_name} is used by another bCourses site and is not available.')
 
         mailing_list.list_name = list_name
-        mailing_list.term_id = int(term_id)
+        mailing_list.term_id = int(term_id) if term_id and term_id.isnumeric() else None
         mailing_list.welcome_email_body = welcome_email_body
         mailing_list.welcome_email_subject = welcome_email_subject
         db.session.add(mailing_list)

--- a/tests/fixtures/canvas/json/course.json
+++ b/tests/fixtures/canvas/json/course.json
@@ -12,8 +12,8 @@
             "enrollment_term_id": 1,
             "grading_standard_id": 1,
             "term": {
-                "name": "Fall 2022",
-                "sis_term_id": "TERM:2022-D"
+                "name": "Fall 2020",
+                "sis_term_id": "TERM:2020-D"
             },
             "time_zone": "America/Los_Angeles",
             "workflow_state": "available"
@@ -69,7 +69,7 @@
         "method": "GET",
         "endpoint": "courses/775390",
         "data": {
-            "id": 8876542,
+            "id": 775390,
             "course_code": "CHEM 1A-LEC-001",
             "name": "General Chemistry",
             "description": "",
@@ -1416,6 +1416,34 @@
         },
         "status_code": 200
     },
+    "search_users_1010101": {
+        "endpoint": "courses/1010101/search_users",
+        "data": [
+            {
+                "id": 4567890,
+                "email": "synthetic.ash@berkeley.edu",
+                "enrollments": [
+                    {
+                      "user_id": 4567890,
+                      "course_id": 1010101,
+                      "type": "TeacherEnrollment",
+                      "enrollment_state": "active",
+                      "role": "TeacherEnrollment",
+                      "last_activity_at": "2023-03-02T06:04:43Z",
+                      "sis_user_id": "300300000",
+                      "html_url": "https://ucberkeley.beta.instructure.com/courses/1234567/users/4567890"
+                    }
+                ],
+                "login_id": "30000",
+                "integration_id": null,
+                "name": "Ash 🤖",
+                "short_name": "Ash 🤖",
+                "sortable_name": "🤖, Ash"
+            }
+        ],
+        "method": "GET",
+        "status_code": 200
+    },
     "search_users_1234567": {
         "endpoint": "courses/1234567/search_users",
         "data": [
@@ -1432,6 +1460,34 @@
                     "last_activity_at": "2023-03-02T06:04:43Z",
                     "sis_user_id": "300300000",
                     "html_url": "https://ucberkeley.beta.instructure.com/courses/1234567/users/4567890"
+                    }
+                ],
+                "login_id": "30000",
+                "integration_id": null,
+                "name": "Ash 🤖",
+                "short_name": "Ash 🤖",
+                "sortable_name": "🤖, Ash"
+            }
+        ],
+        "method": "GET",
+        "status_code": 200
+    },
+    "search_users_775390": {
+        "endpoint": "courses/775390/search_users",
+        "data": [
+            {
+                "id": 4567890,
+                "email": "synthetic.ash@berkeley.edu",
+                "enrollments": [
+                    {
+                    "user_id": 4567890,
+                    "course_id": 775390,
+                    "type": "TeacherEnrollment",
+                    "enrollment_state": "active",
+                    "role": "TeacherEnrollment",
+                    "last_activity_at": "2023-03-02T06:04:43Z",
+                    "sis_user_id": "300300000",
+                    "html_url": "https://ucberkeley.beta.instructure.com/courses/775390/users/4567890"
                     }
                 ],
                 "login_id": "30000",


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-335

If a canvas_site has term = 'default' then we set term_id = null in the `canvas_site_mailing_lists` table. Good?