### PR TITLE
RIP-341: enrollments update runs syncrhonously within RQ job thread

### DIFF
--- a/ripley/api/canvas_site_controller.py
+++ b/ripley/api/canvas_site_controller.py
@@ -37,7 +37,6 @@ from ripley.lib.http import tolerant_jsonify
 from ripley.lib.util import to_bool_or_none
 from ripley.merged.grade_distributions import get_grade_distribution_with_demographics, get_grade_distribution_with_enrollments
 from ripley.merged.roster import canvas_site_roster, canvas_site_roster_csv
-from ripley.models.job_history import JobHistory
 
 
 @app.route('/api/canvas_site/provision')
@@ -193,14 +192,6 @@ def get_provision_status():
     job = get_job(job_id)
     job_status = job.get_status(refresh=True)
     job_data = job.get_meta(refresh=True)
-    if 'enrollment_update_job_id' in job_data:
-        enrollment_update_job = JobHistory.get_by_id(job_data['enrollment_update_job_id'])
-        if enrollment_update_job.failed:
-            job_status = 'failed'
-        elif enrollment_update_job.finished_at:
-            job_status = 'finished'
-        else:
-            job_status = 'started'
     if 'sis_import_id' in job_data:
         sis_import = canvas.get_sis_import(job_data['sis_import_id'])
         if not sis_import:

--- a/ripley/factory.py
+++ b/ripley/factory.py
@@ -60,7 +60,7 @@ def _initialize_queue(app):
     global q
     redis_conn = get_redis_conn(app)
     with Connection(redis_conn):
-        q = Queue(is_async=(not app.config['TESTING']))
+        q = Queue(is_async=(not app.config['TESTING']), default_timeout=600)
 
 
 def _register_jobs(app):

--- a/ripley/jobs/bcourses_provision_site_job.py
+++ b/ripley/jobs/bcourses_provision_site_job.py
@@ -89,7 +89,6 @@ class BcoursesProvisionSiteJob(BcoursesRefreshBaseJob):
                 _csv.filehandle.close()
 
             self.upload_results(csv_set, timestamp)
-            app.logger.info('Job complete.')
 
         CanvasSynchronization.update(enrollments=this_sync, instructors=this_sync)
         app.logger.info(f'bCourses site provisioning job (mode={self.__class__.__name__}) complete.')

--- a/src/views/CourseManageOfficialSections.vue
+++ b/src/views/CourseManageOfficialSections.vue
@@ -187,10 +187,10 @@
           <div v-if="jobStatus === 'sendingRequest'">
             Sending request...
           </div>
-          <div v-if="$_.includes(['queued', 'initializing', 'created'], jobStatus)">
+          <div v-if="'queued' === jobStatus">
             Request sent. Awaiting processing...
           </div>
-          <div v-if="$_.includes(['started', 'importing'], jobStatus)">
+          <div v-if="'started' === jobStatus">
             Request received. Updating sections...
           </div>
           <div v-if="'finished' === jobStatus">
@@ -457,9 +457,9 @@ export default {
         courseProvisionJobStatus(this.backgroundJobId).then(
           response => {
             this.jobStatus = response.jobStatus
-            if (!(this.$_.includes(['started', 'queued', 'initializing', 'created', 'importing'], this.jobStatus))) {
+            if (!(this.$_.includes(['started', 'queued'], this.jobStatus))) {
               clearInterval(this.exportTimer)
-              if (this.$_.includes(['imported', 'finished'], this.jobStatus) && response.workflowState === 'imported') {
+              if (this.jobStatus === 'finished' && response.workflowState === 'imported') {
                 this.jobStatusMessage = 'The sections in this course site have been updated successfully.'
               } else {
                 this.jobStatusMessage = 'An error has occurred with your request. Please try again or contact bCourses support.'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-341

The RQ job was terminating before the background enrollments update was finished.

Also, we need to allow more than one enrollments update job (BcoursesProvisionSiteJob) to run concurrently, and we have no way of knowing which JobHistory row corresponds to which running job.