### PR TITLE
RIP-370 Restore submit type to buttons in LTI tools

### DIFF
--- a/src/components/bcourses/create/ConfirmationStep.vue
+++ b/src/components/bcourses/create/ConfirmationStep.vue
@@ -64,6 +64,7 @@
               aria-controls="page-create-course-site-steps-container"
               aria-label="Create Course Site"
               color="primary"
+              type="submit"
               :disabled="!trim(siteName) || !trim(siteAbbreviation)"
             >
               Create Course Site

--- a/src/components/bcourses/create/CreateCourseSiteHeader.vue
+++ b/src/components/bcourses/create/CreateCourseSiteHeader.vue
@@ -37,6 +37,7 @@
                   aria-controls="page-create-course-site-steps-container"
                   aria-label="Load official sections for instructor"
                   color="primary"
+                  type="submit"
                   :disabled="!uid"
                 >
                   As instructor
@@ -81,6 +82,7 @@
               id="sections-by-ids-button"
               aria-controls="page-create-course-site-steps-container"
               color="primary"
+              type="submit"
               :disabled="!trim(sectionIds)"
             >
               Review matching Section IDs

--- a/src/views/CreateProjectSite.vue
+++ b/src/views/CreateProjectSite.vue
@@ -42,6 +42,7 @@
           aria-controls="page-reader-alert"
           class="mr-2"
           color="primary"
+          type="submit"
           :disabled="isCreating || !trim(name)"
           @click="create"
         >

--- a/src/views/UserProvision.vue
+++ b/src/views/UserProvision.vue
@@ -55,6 +55,7 @@
               id="user-provision-import-btn"
               class="text-no-wrap mr-4 my-2"
               color="primary"
+              type="submit"
               :disabled="importButtonDisabled"
             >
               <span v-if="!importProcessing">Import Users</span>


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-370

These were not extraneous styles but (because actions are set on the enclosing form elements) necessary to make the buttons do things.