### PR TITLE
RIP-401, the 'this' is kinda necessary

### DIFF
--- a/src/views/CreateProjectSite.vue
+++ b/src/views/CreateProjectSite.vue
@@ -86,7 +86,7 @@ export default {
       this.$router.push({path: '/create_site'})
     },
     create() {
-      if (!this.isCreating && trim(name)) {
+      if (!this.isCreating && trim(this.name)) {
         this.error = null
         this.isCreating = true
         this.$announcer.polite('Creating new project site...')


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-401

The 'create' button would do nothing cuz `name` is undefined. This needs `this`.