### PR TITLE
RIP-405: allows site owners to find a user to add

### DIFF
--- a/ripley/api/canvas_site_controller.py
+++ b/ripley/api/canvas_site_controller.py
@@ -194,7 +194,7 @@ def get_official_course_sections(canvas_site_id):
         'canvasSite': {
             'canEdit': can_edit,
             'officialSections': official_sections,
-            'term': term.to_api_json(),
+            'term': term.to_api_json() if term else None,
         },
         'teachingTerms': teaching_terms,
     })

--- a/ripley/api/canvas_user_controller.py
+++ b/ripley/api/canvas_user_controller.py
@@ -35,21 +35,21 @@ from ripley.lib.http import tolerant_jsonify
 
 @app.route('/api/canvas_user/<canvas_site_id>/options')
 @login_required
-@canvas_role_required('TaEnrollment', 'TeacherEnrollment', 'Lead TA')
+@canvas_role_required('DesignerEnrollment', 'Lead TA', 'Maintainer', 'Owner', 'TaEnrollment', 'TeacherEnrollment')
 def get_add_user_options(canvas_site_id):
     course = canvas.get_course(canvas_site_id)
     if not course:
         raise ResourceNotFoundError(f'No Canvas course site found with ID {canvas_site_id}')
     course_sections = canvas.get_course_sections(canvas_site_id)
     return tolerant_jsonify({
-        'courseSections': [{'id': section.id, 'name': section.name} for section in course_sections if section.sis_section_id],
+        'courseSections': [{'id': section.id, 'name': section.name} for section in course_sections],
         'grantingRoles': _get_grantable_roles(course.account_id),
     })
 
 
 @app.route('/api/canvas_user/<canvas_site_id>/users', methods=['POST'])
 @login_required
-@canvas_role_required('TaEnrollment', 'TeacherEnrollment', 'Lead TA')
+@canvas_role_required('DesignerEnrollment', 'Lead TA', 'Maintainer', 'Owner', 'TaEnrollment', 'TeacherEnrollment')
 def canvas_site_add_user(canvas_site_id):
     course = canvas.get_course(canvas_site_id)
     if not course:
@@ -76,7 +76,7 @@ def canvas_site_add_user(canvas_site_id):
 
 @app.route('/api/canvas_user/search')
 @login_required
-@canvas_role_required('TaEnrollment', 'TeacherEnrollment', 'Lead TA')
+@canvas_role_required('DesignerEnrollment', 'Lead TA', 'Maintainer', 'Owner', 'TaEnrollment', 'TeacherEnrollment')
 def search_users():
     search_text = request.args.get('searchText')
     if not search_text:

--- a/ripley/lib/canvas_utils.py
+++ b/ripley/lib/canvas_utils.py
@@ -257,10 +257,12 @@ def get_official_sections(canvas_site_id):
     canvas_sections = [canvas_section_to_api_json(cs) for cs in canvas_sections if cs.sis_section_id]
     canvas_sections_by_id = {cs['id']: cs for cs in canvas_sections if cs['id']}
     section_ids = list(canvas_sections_by_id.keys())
-    term_id = canvas_sections[0]['termId']
-    sis_sections = sort_course_sections(
-        data_loch.get_sections(term_id, section_ids) or [],
-    )
+    sis_sections = []
+    if len(canvas_sections):
+        term_id = canvas_sections[0]['termId']
+        sis_sections = sort_course_sections(
+            data_loch.get_sections(term_id, section_ids) or [],
+        )
     if len(sis_sections) != len(section_ids):
         app.logger.warning(f'Canvas site ID {canvas_site_id} has {len(section_ids)} sections, but SIS has {len(sis_sections)} sections.')
 

--- a/tests/fixtures/calnet/user_for_uid_90000.json
+++ b/tests/fixtures/calnet/user_for_uid_90000.json
@@ -3,10 +3,10 @@
     "csid": "30090000",
     "deptCode": "SYPSY",
     "email": "____________berkeley.edu",
-    "firstName": "Ellen",
+    "firstName": "Bolaji",
     "isExpiredPerLdap": false,
-    "lastName": "Ripley",
-    "name": "Ellen Ripley",
+    "lastName": "Badejo",
+    "name": "Bolaji Badejo",
     "sid": "30090000",
     "uid": "90000"
 }

--- a/tests/fixtures/canvas/json/account.json
+++ b/tests/fixtures/canvas/json/account.json
@@ -1002,7 +1002,7 @@
             }
         ]
     },
-    "get_roles": {
+    "get_roles_1": {
         "method": "GET",
         "endpoint": "accounts/1/roles",
         "data": [
@@ -1412,6 +1412,75 @@
                 "last_updated_at": "2022-12-07T21:10:07Z",
                 "base_role_type": "DesignerEnrollment",
                 "workflow_state": "built_in",
+                "created_at": "2020-09-09T17:04:57-07:00",
+                "permissions": {
+                    "add_designer_to_course": {
+                        "enabled": true,
+                        "locked": false,
+                        "readonly": false,
+                        "explicit": true,
+                        "prior_default": false,
+                        "group": "manage_course_designer_enrollments",
+                        "applies_to_self": true,
+                        "applies_to_descendants": true
+                    },
+                    "add_observer_to_course": {
+                        "enabled": true,
+                        "locked": false,
+                        "readonly": false,
+                        "explicit": true,
+                        "prior_default": true,
+                        "group": "manage_course_observer_enrollments",
+                        "applies_to_self": true,
+                        "applies_to_descendants": true
+                    },
+                    "add_student_to_course": {
+                        "enabled": true,
+                        "locked": false,
+                        "readonly": false,
+                        "explicit": false,
+                        "group": "manage_course_student_enrollments",
+                        "applies_to_self": true,
+                        "applies_to_descendants": true
+                    },
+                    "add_ta_to_course": {
+                        "enabled": true,
+                        "locked": false,
+                        "readonly": false,
+                        "explicit": true,
+                        "prior_default": false,
+                        "group": "manage_course_ta_enrollments",
+                        "applies_to_self": true,
+                        "applies_to_descendants": true
+                    },
+                    "add_teacher_to_course": {
+                        "enabled": true,
+                        "locked": false,
+                        "readonly": false,
+                        "explicit": true,
+                        "prior_default": false,
+                        "group": "manage_course_teacher_enrollments",
+                        "applies_to_self": true,
+                        "applies_to_descendants": true
+                    },
+                    "manage_students": {
+                        "enabled": true,
+                        "locked": false,
+                        "readonly": false,
+                        "explicit": false,
+                        "applies_to_self": true,
+                        "applies_to_descendants": true
+                    }
+                },
+                "is_account_role": "false"
+            },
+            {
+                "id": 1766,
+                "role": "Owner",
+                "label": "Owner",
+                "last_updated_at": "2022-12-07T21:10:07Z",
+                "base_role_type": "TeacherEnrollment",
+                "workflow_state": "active",
                 "created_at": "2020-09-09T17:04:57-07:00",
                 "permissions": {
                     "add_designer_to_course": {

--- a/tests/fixtures/canvas/json/course.json
+++ b/tests/fixtures/canvas/json/course.json
@@ -121,7 +121,7 @@
         },
         "status_code": 200
     },
-    "get_enrollments_4567890": {
+    "get_enrollments_8876542_4567890": {
         "method": "GET",
         "endpoint": "courses/8876542/users/4567890?include=enrollments",
         "data": {
@@ -151,7 +151,7 @@
         },
         "status_code": 200
     },
-    "get_enrollments_4567890_past": {
+    "get_enrollments_8876542_4567890_past": {
         "method": "GET",
         "endpoint": "courses/1010101/users/4567890?include=enrollments",
         "data": {
@@ -181,7 +181,37 @@
         },
         "status_code": 200
     },
-    "get_enrollments_6789012": {
+    "get_enrollments_8876542_5678234": {
+        "method": "GET",
+        "endpoint": "courses/8876542/users/5678234?include=enrollments",
+        "data": {
+            "id": 5678234,
+            "name": "Bolaji Badejo",
+            "short_name": "Bolaji Badejo",
+            "sortable_name": "Badejo, Bolaji",
+            "integration_id": null,
+            "login_id": "90000",
+            "sis_user_id": "30090000",
+            "enrollments": [
+                {
+                    "id": 103,
+                    "user_id": 5678234,
+                    "course_id": 8876542,
+                    "course_section_id": 10000,
+                    "type": "TaEnrollment",
+                    "enrollment_state": "active",
+                    "role": "Owner",
+                    "last_activity_at": "2023-03-02T06:04:43Z",
+                    "sis_user_id": "30090000",
+                    "sis_course_id": "CRS:ANTHRO-189-2023-B",
+                    "sis_section_id": "2023-B-32936",
+                    "html_url": "https://ucberkeley.beta.instructure.com/courses/8876542/users/5678234"
+                }
+            ]
+        },
+        "status_code": 200
+    },
+    "get_enrollments_8876542_6789012": {
         "method": "GET",
         "endpoint": "courses/8876542/users/6789012?include=enrollments",
         "data": {
@@ -211,7 +241,7 @@
         },
         "status_code": 200
     },
-    "get_enrollments_7890123": {
+    "get_enrollments_8876542_7890123": {
         "method": "GET",
         "endpoint": "courses/8876542/users/7890123?include=enrollments",
         "data": {
@@ -241,7 +271,7 @@
         },
         "status_code": 200
     },
-    "get_enrollments_8901234": {
+    "get_enrollments_8876542_8901234": {
         "method": "GET",
         "endpoint": "courses/8876542/users/8901234?include=enrollments",
         "data": {

--- a/tests/test_api/test_canvas_egrades_export_controller.py
+++ b/tests/test_api/test_canvas_egrades_export_controller.py
@@ -73,7 +73,7 @@ class TestEgradeExportOptions:
                     f'get_by_id_{canvas_site_id}',
                     f'get_sections_{canvas_site_id}',
                     f'get_settings_{canvas_site_id}',
-                    'get_enrollments_4567890',
+                    'get_enrollments_8876542_4567890',
                 ],
                 'user': [f'profile_{teacher_uid}'],
             }, m)
@@ -147,7 +147,7 @@ class TestEgradesExportPrepare:
                     f'get_by_id_{canvas_site_id}',
                     f'get_sections_{canvas_site_id}',
                     f'get_settings_{canvas_site_id}',
-                    'get_enrollments_4567890',
+                    'get_enrollments_8876542_4567890',
                 ],
                 'user': [f'profile_{teacher_uid}'],
             }, m)
@@ -276,7 +276,7 @@ class TestOfficialCanvasCourse:
                 'course': [
                     f'get_by_id_{canvas_site_id}',
                     f'get_sections_{canvas_site_id}',
-                    'get_enrollments_4567890',
+                    'get_enrollments_8876542_4567890',
                 ],
                 'user': [f'profile_{teacher_uid}'],
             }, m)
@@ -295,7 +295,7 @@ class TestOfficialCanvasCourse:
                     'course': [
                         f'get_by_id_{canvas_site_id}',
                         f'get_sections_{canvas_site_id}',
-                        'get_enrollments_4567890',
+                        'get_enrollments_8876542_4567890',
                     ],
                     'user': [f'profile_{teacher_uid}'],
                 }, m)

--- a/tests/test_api/test_canvas_site_controller.py
+++ b/tests/test_api/test_canvas_site_controller.py
@@ -57,7 +57,7 @@ class TestCanvasSiteEditSections:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['get_admins', 'get_by_id'],
-                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_7890123'],
+                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_8876542_7890123'],
                 'user': ['profile_60000'],
             }, m)
             canvas_site_id = '8876542'
@@ -69,7 +69,7 @@ class TestCanvasSiteEditSections:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['get_admins', 'get_by_id'],
-                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_6789012'],
+                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_8876542_6789012'],
                 'user': ['profile_50000'],
             }, m)
             canvas_site_id = '8876542'
@@ -81,7 +81,7 @@ class TestCanvasSiteEditSections:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['create_sis_import', 'get_admins', 'get_by_id', 'get_sis_import'],
-                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_4567890'],
+                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_8876542_4567890'],
                 'user': ['profile_30000'],
             }, m)
             canvas_site_id = '8876542'
@@ -95,7 +95,7 @@ class TestCanvasSiteEditSections:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['get_admins'],
-                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_4567890'],
+                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_8876542_4567890'],
                 'user': ['profile_30000'],
             }, m)
             canvas_site_id = '8876542'
@@ -129,7 +129,7 @@ class TestCanvasSiteProvision:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['get_admins', 'get_terms'],
-                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_4567890'],
+                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_8876542_4567890'],
                 'user': ['profile_30000'],
             }, m)
             fake_auth.login(canvas_site_id=None, uid=teacher_uid)
@@ -141,7 +141,7 @@ class TestCanvasSiteProvision:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['get_admins', 'get_terms'],
-                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_4567890'],
+                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_8876542_4567890'],
                 'user': ['profile_30000', f'profile_{admin_uid}'],
             }, m)
             fake_auth.login(canvas_site_id=None, uid=admin_uid)
@@ -153,7 +153,7 @@ class TestCanvasSiteProvision:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['get_admins', 'get_terms'],
-                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_4567890'],
+                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_8876542_4567890'],
                 'user': ['profile_30000', f'profile_{admin_uid}'],
             }, m)
             fake_auth.login(canvas_site_id=None, uid=admin_uid)
@@ -197,7 +197,7 @@ class TestCanvasSiteProvisionSections:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['get_admins', 'get_terms'],
-                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_7890123'],
+                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_8876542_7890123'],
                 'user': ['profile_60000'],
             }, m)
             canvas_site_id = '8876542'
@@ -225,7 +225,7 @@ class TestCanvasSiteProvisionSections:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['get_admins', 'get_terms'],
-                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_6789012'],
+                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_8876542_6789012'],
                 'user': ['profile_50000'],
             }, m)
             canvas_site_id = '8876542'
@@ -253,7 +253,7 @@ class TestCanvasSiteProvisionSections:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['get_admins', 'get_terms'],
-                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_4567890'],
+                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_8876542_4567890'],
                 'user': ['profile_30000'],
             }, m)
             canvas_site_id = '8876542'
@@ -400,7 +400,7 @@ class TestCreateCourseSite:
                 has_canvas_account = unauthorized_uid != no_canvas_account_uid
                 register_canvas_uris(app, {
                     'account': ['get_admins', f'get_courses_{account_id}'],
-                    'course': [f'get_by_id_{canvas_site_id}', f'get_sections_{canvas_site_id}', 'get_enrollments_4567890'],
+                    'course': [f'get_by_id_{canvas_site_id}', f'get_sections_{canvas_site_id}', 'get_enrollments_8876542_4567890'],
                     'user': [f'profile_{unauthorized_uid}'] if has_canvas_account else [],
                 }, m)
                 fake_auth.login(canvas_site_id=canvas_site_id, uid=unauthorized_uid)
@@ -460,7 +460,7 @@ class TestCreateProjectSite:
                 has_canvas_account = unauthorized_uid != no_canvas_account_uid
                 register_canvas_uris(app, {
                     'account': ['get_admins', f'get_courses_{account_id}'],
-                    'course': [f'get_by_id_{canvas_site_id}', f'get_sections_{canvas_site_id}', 'get_enrollments_4567890'],
+                    'course': [f'get_by_id_{canvas_site_id}', f'get_sections_{canvas_site_id}', 'get_enrollments_8876542_4567890'],
                     'user': [f'profile_{unauthorized_uid}'] if has_canvas_account else [],
                 }, m)
                 fake_auth.login(canvas_site_id=canvas_site_id, uid=unauthorized_uid)
@@ -492,7 +492,7 @@ class TestCreateProjectSite:
                         f'get_by_id_{canvas_site_id}',
                         f'get_by_id_{project_site_id}',
                         f'get_content_migrations_{project_site_id}',
-                        'get_enrollments_4567890',
+                        'get_enrollments_8876542_4567890',
                         f'get_sections_{canvas_site_id}',
                         f'get_tabs_{project_site_id}',
                         'post_course_enrollments_3030303',
@@ -533,7 +533,7 @@ class TestGetRoster:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['get_admins'],
-                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_7890123'],
+                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_8876542_7890123'],
                 'user': ['profile_60000'],
             }, m)
             canvas_site_id = '8876542'
@@ -545,7 +545,7 @@ class TestGetRoster:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['get_admins'],
-                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_6789012'],
+                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_8876542_6789012'],
                 'user': ['profile_50000'],
             }, m)
             canvas_site_id = '8876542'
@@ -560,7 +560,7 @@ class TestGetRoster:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['get_admins'],
-                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_4567890'],
+                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_8876542_4567890'],
                 'user': ['profile_10000'],
             }, m)
             canvas_site_id = '8876542'
@@ -603,7 +603,7 @@ class TestGetRoster:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['get_admins'],
-                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_4567890'],
+                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_8876542_4567890'],
                 'user': ['profile_30000'],
             }, m)
             canvas_site_id = '8876542'
@@ -618,7 +618,7 @@ class TestGetRoster:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['get_admins'],
-                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_4567890'],
+                'course': ['get_by_id_8876542', 'get_sections_8876542', 'get_enrollments_8876542_4567890'],
                 'user': ['profile_40000'],
             }, m)
             canvas_site_id = '8876542'
@@ -714,7 +714,7 @@ class TestGradeDistributions:
         with requests_mock.Mocker() as m:
             register_canvas_uris(app, {
                 'account': ['get_admins'],
-                'course': ['get_by_id_1010101', 'get_sections_1010101', 'get_enrollments_4567890_past'],
+                'course': ['get_by_id_1010101', 'get_sections_1010101', 'get_enrollments_8876542_4567890_past'],
                 'user': ['profile_30000'],
             }, m)
             canvas_site_id = '1010101'

--- a/tests/test_api/test_mailing_list_controller.py
+++ b/tests/test_api/test_mailing_list_controller.py
@@ -324,7 +324,7 @@ class TestActivateMailingList:
         with requests_mock.Mocker() as m:
             canvas_site_id = '8876542'
             register_canvas_uris(app, {
-                'course': [f'get_by_id_{canvas_site_id}', f'get_sections_{canvas_site_id}', 'get_enrollments_4567890'],
+                'course': [f'get_by_id_{canvas_site_id}', f'get_sections_{canvas_site_id}', 'get_enrollments_8876542_4567890'],
                 'user': ['profile_30000'],
             }, m)
             fake_auth.login(canvas_site_id=canvas_site_id, uid=admin_uid)


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-405

Also some refactoring.