### PR TITLE
RIP-397, import materialdesignicons.min.css in main.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import '@mdi/font/css/materialdesignicons.min.css'
 import App from './App.vue'
 import axios from 'axios'
 import moment from 'moment'

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -1,4 +1,3 @@
-import '@mdi/font/css/materialdesignicons.css'
 import 'vuetify/styles'
 import {aliases, mdi} from 'vuetify/iconsets/mdi'
 import {createVuetify} from 'vuetify'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-397

Fwiw, this matches Diablo's setup. A minified CSS download + more centralized import = reliable icons? Fingers crossed.