### PR TITLE
RIP-433, better use of @vue-a11y/announcer; btn order per accessibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ckeditor/ckeditor5-vue": "5.1.0",
         "@mdi/font": "7.2.96",
         "@vue-a11y/announcer": "3.1.5",
-        "axios": "1.5.0",
+        "axios": "1.5.1",
         "core-js": "3.32.2",
         "highcharts-vue": "1.4.3",
         "js-file-download": "0.4.12",
@@ -24,8 +24,8 @@
         "pinia": "2.1.6",
         "roboto-fontface": "*",
         "vue": "3.3.4",
-        "vue-router": "4.2.4",
-        "vuetify": "3.3.16",
+        "vue-router": "4.2.5",
+        "vuetify": "3.3.19",
         "webfontloader": "1.6.28"
       },
       "devDependencies": {
@@ -1472,9 +1472,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
-      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
+      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -3514,9 +3514,9 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.2.4.tgz",
-      "integrity": "sha512-9PISkmaCO02OzPVOMq2w82ilty6+xJmQrarYZDkjZBfl4RvYAlt4PKnEX21oW4KTtWfa9OuO/b3qk1Od3AEdCQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.2.5.tgz",
+      "integrity": "sha512-DIUpKcyg4+PTQKfFPX88UWhlagBEBEfJ5A8XDXRJLUnZOvcpMF8o/dnL90vpVkGaPbjvXazV/rC1qBKrZlFugw==",
       "dependencies": {
         "@vue/devtools-api": "^6.5.0"
       },
@@ -3555,9 +3555,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.3.16.tgz",
-      "integrity": "sha512-vVfUroT5lSU+yOZAf7JlGm2j3dCR4BQml8Al27+/Uh0YW+97/CyUqOzo6IzMCt/bXLvnRerJ5fCAJtQYWnwfLA==",
+      "version": "3.3.19",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.3.19.tgz",
+      "integrity": "sha512-6/byccc79pq2LmveSgte/AXqyEXkq3aFMxKMwoizsDzDPH4vz/44wRx0+TxhiDk4+n8WOhMa2VlXq1xsJIi1HA==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },
@@ -4653,9 +4653,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
-      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
+      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -6088,9 +6088,9 @@
       }
     },
     "vue-router": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.2.4.tgz",
-      "integrity": "sha512-9PISkmaCO02OzPVOMq2w82ilty6+xJmQrarYZDkjZBfl4RvYAlt4PKnEX21oW4KTtWfa9OuO/b3qk1Od3AEdCQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.2.5.tgz",
+      "integrity": "sha512-DIUpKcyg4+PTQKfFPX88UWhlagBEBEfJ5A8XDXRJLUnZOvcpMF8o/dnL90vpVkGaPbjvXazV/rC1qBKrZlFugw==",
       "requires": {
         "@vue/devtools-api": "^6.5.0"
       }
@@ -6117,9 +6117,9 @@
       }
     },
     "vuetify": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.3.16.tgz",
-      "integrity": "sha512-vVfUroT5lSU+yOZAf7JlGm2j3dCR4BQml8Al27+/Uh0YW+97/CyUqOzo6IzMCt/bXLvnRerJ5fCAJtQYWnwfLA==",
+      "version": "3.3.19",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.3.19.tgz",
+      "integrity": "sha512-6/byccc79pq2LmveSgte/AXqyEXkq3aFMxKMwoizsDzDPH4vz/44wRx0+TxhiDk4+n8WOhMa2VlXq1xsJIi1HA==",
       "requires": {}
     },
     "webfontloader": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@ckeditor/ckeditor5-vue": "5.1.0",
     "@mdi/font": "7.2.96",
     "@vue-a11y/announcer": "3.1.5",
-    "axios": "1.5.0",
+    "axios": "1.5.1",
     "core-js": "3.32.2",
     "highcharts-vue": "1.4.3",
     "js-file-download": "0.4.12",
@@ -30,8 +30,8 @@
     "pinia": "2.1.6",
     "roboto-fontface": "*",
     "vue": "3.3.4",
-    "vue-router": "4.2.4",
-    "vuetify": "3.3.16",
+    "vue-router": "4.2.5",
+    "vuetify": "3.3.19",
     "webfontloader": "1.6.28"
   },
   "devDependencies": {

--- a/src/components/bcourses/create/ConfirmationStep.vue
+++ b/src/components/bcourses/create/ConfirmationStep.vue
@@ -66,17 +66,7 @@
     <v-row>
       <v-col cols="12">
         <div class="align-center d-flex float-right">
-          <div class="pr-2">
-            <v-btn
-              id="go-back-button"
-              :disabled="isCreating"
-              variant="text"
-              @click="goBack"
-            >
-              Cancel
-            </v-btn>
-          </div>
-          <div>
+          <div class="mr-1">
             <v-btn
               id="create-course-site-button"
               color="primary"
@@ -94,6 +84,16 @@
               <span v-if="!isCreating">
                 Create Course Site
               </span>
+            </v-btn>
+          </div>
+          <div>
+            <v-btn
+              id="go-back-button"
+              :disabled="isCreating"
+              variant="text"
+              @click="goBack"
+            >
+              Cancel
             </v-btn>
           </div>
         </div>

--- a/src/components/bcourses/create/SelectSectionsStep.vue
+++ b/src/components/bcourses/create/SelectSectionsStep.vue
@@ -93,21 +93,22 @@
         </v-expansion-panels>
         <div class="d-flex justify-end mb-4 pr-8">
           <v-btn
+            id="page-create-course-site-continue"
+            aria-label="Continue to next step"
+            class="mr-1"
+            color="primary"
+            :disabled="!selectedSectionsList.length"
+            @click="showConfirmation"
+          >
+            Next
+          </v-btn>
+          <v-btn
             id="page-create-course-site-cancel"
             aria-label="Cancel and return to Site Creation Overview"
             variant="text"
             @click="cancel"
           >
             Cancel
-          </v-btn>
-          <v-btn
-            id="page-create-course-site-continue"
-            aria-label="Continue to next step"
-            color="primary"
-            :disabled="!selectedSectionsList.length"
-            @click="showConfirmation"
-          >
-            Next
           </v-btn>
         </div>
       </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,9 @@ initializeAxios(app, axios)
 // Globals
 app.config.globalProperties.$isInIframe = !!window.parent.frames.length
 app.config.globalProperties.$moment = moment
-app.config.globalProperties.$ready = (label?: string, focusTarget?: string) => useContextStore().loadingComplete(label, focusTarget)
+app.config.globalProperties.$ready = (focusTarget?: string) => {
+  useContextStore().loadingComplete(focusTarget)
+}
 
 const apiBaseUrl = import.meta.env.VITE_APP_API_BASE_URL
 

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -2,6 +2,7 @@ import accessibility from 'highcharts/modules/accessibility'
 import axios from '@/plugins/axios'
 import type {App} from 'vue'
 import Highcharts from 'highcharts'
+import router from '@/router'
 import VueAnnouncer from '@vue-a11y/announcer'
 import vuetify from './vuetify'
 import {createPinia} from 'pinia'
@@ -13,6 +14,6 @@ export function registerPlugins (app: App) {
   app
     .use(axios, {baseUrl: import.meta.env.VITE_APP_API_BASE_URL})
     .use(createPinia())
-    .use(VueAnnouncer)
+    .use(VueAnnouncer, {router})
     .use(vuetify)
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -49,111 +49,146 @@ const routes:RouteRecordRaw[] = [
     children: [
       {
         component: CanvasSiteSummary,
+        meta: {
+          announcer: {
+            skip: true
+          }
+        },
         path: '/canvas_site/:id'
       },
       {
         component: CourseAddUser,
         path: '/add_user',
         meta: {
-          title: 'Find a User to Add'
+          announcer: {
+            message: 'Find a User to Add'
+          }
         }
       },
       {
         component: CourseGradeDistribution,
         path: '/grade_distribution',
         meta: {
-          title: 'Grade Distribution'
+          announcer: {
+            message: 'Grade Distribution'
+          }
         }
       },
       {
         component: CourseGradeExport,
         path: '/export_grade',
         meta: {
-          title: 'E-Grade Export'
+          announcer: {
+            message: 'E-Grade Export'
+          }
         }
       },
       {
         component: CourseManageOfficialSections,
         path: '/manage_official_sections',
         meta: {
-          title: 'Official Sections'
+          announcer: {
+            message: 'Official Sections'
+          }
         }
       },
       {
         component: Profile,
         path: '/profile/:uid',
         meta: {
-          title: 'Profile'
+          announcer: {
+            message: 'Profile'
+          }
         }
       },
       {
         component: Roster,
         path: '/roster',
         meta: {
-          title: 'Roster Photos'
+          announcer: {
+            message: 'Roster Photos'
+          }
         }
       },
       {
         component: SiteCreation,
         path: '/create_site',
         meta: {
-          title: 'bCourses Site Creation'
+          announcer: {
+            message: 'bCourses Site Creation'
+          }
         }
       },
       {
         component: CreateCourseSite,
         path: '/create_course_site',
         meta: {
-          title: 'Create a Course Site'
+          announcer: {
+            message: 'Create a Course Site'
+          }
         }
       },
       {
         component: CreateProjectSite,
         path: '/create_project_site',
         meta: {
-          title: 'Create a Project Site'
+          announcer: {
+            message: 'Create a Project Site'
+          }
         }
       },
       {
         component: MailingListCreate,
         path: '/mailing_list/create',
         meta: {
-          title: 'Create Mailing List'
+          announcer: {
+            message: 'Create Mailing List'
+          }
         }
       },
       {
         component: MailingListSelectCourse,
         path: '/mailing_list/select_course',
         meta: {
-          title: 'Select Course Site'
+          announcer: {
+            message: 'Select Course Site'
+          }
         }
       },
       {
         component: MailingListCreate,
         path: '/mailing_list/create/:canvasSiteId',
         meta: {
-          title: 'Create Mailing List'
+          announcer: {
+            message: 'Create Mailing List'
+          }
         }
       },
       {
         component: MailingListUpdate,
         path: '/mailing_list/update',
         meta: {
-          title: 'Update Mailing List'
+          announcer: {
+            message: 'Update Mailing List'
+          }
         }
       },
       {
         component: SendWelcomeEmail,
         path: '/mailing_list/send_welcome_email',
         meta: {
-          title: 'Send Welcome Email'
+          announcer: {
+            message: 'Send Welcome Email'
+          }
         }
       },
       {
         component: UserProvision,
         path: '/provision_user',
         meta: {
-          title: 'bCourses User Provision'
+          announcer: {
+            message: 'bCourses User Provision'
+          }
         }
       },
       {
@@ -161,6 +196,9 @@ const routes:RouteRecordRaw[] = [
         name: 'Welcome',
         path: '/welcome',
         meta: {
+          announcer: {
+            message: 'Welcome'
+          },
           isHome: true
         }
       }
@@ -174,7 +212,11 @@ const routes:RouteRecordRaw[] = [
       {
         path: '/jobs',
         component: Jobs,
-        meta: {title: 'MU-TH-UR 6000'}
+        meta: {
+          announcer: {
+            message: 'MU-TH-UR 6000'
+          }
+        }
       }
     ]
   },
@@ -202,7 +244,7 @@ const router = createRouter({
 router.afterEach((to: any) => {
   useContextStore().loadingStart()
   useContextStore().resetApplicationState()
-  const title = get(to, 'meta.title') || capitalize(to.name) || 'Welcome'
+  const title = get(to, 'announcer.message') || capitalize(to.name) || 'bCourses'
   document.title = `${title} | UC Berkeley`
 })
 

--- a/src/stores/context.ts
+++ b/src/stores/context.ts
@@ -23,13 +23,8 @@ export const useContextStore = defineStore('context', {
     isLoading: false
   }),
   actions: {
-    loadingComplete(label?: string, focusTarget?: string) {
-      document.title = `${label || 'bCourses'} | UC Berkeley`
+    loadingComplete(focusTarget?: string) {
       this.isLoading = false
-      if (label) {
-        // TODO: use '@vue-a11y/announcer' instead
-        // state.screenReaderAlert = `${label} page is ready`
-      }
       if (focusTarget) {
         putFocusNextTick(focusTarget)
       } else {
@@ -47,11 +42,7 @@ export const useContextStore = defineStore('context', {
         }).then(noop)
       }
     },
-    loadingStart(label?: string) {
-      if (label) {
-        // TODO: use '@vue-a11y/announcer'
-        console.log(`TODO: Screen-reader announce "${label}"`)
-      }
+    loadingStart() {
       this.isLoading = true
     },
     resetApplicationState() {

--- a/src/views/CourseAddUser.vue
+++ b/src/views/CourseAddUser.vue
@@ -335,7 +335,7 @@ export default {
       this.showUnauthorized
     ).catch(this.showUnauthorized
     ).finally(() => {
-      this.$ready('Find Person to Add')
+      this.$ready()
     })
   },
   methods: {

--- a/src/views/CourseGradeDistribution.vue
+++ b/src/views/CourseGradeDistribution.vue
@@ -113,7 +113,7 @@ export default {
         this.gradeDistribution = data
         this.loadPrimarySeries()
       }
-    ).finally(() => this.$ready('Grade Distribution'))
+    ).finally(() => this.$ready())
   },
   methods: {
     changeSeriesColor(chartSettings) {

--- a/src/views/CreateCourseSite.vue
+++ b/src/views/CreateCourseSite.vue
@@ -130,7 +130,7 @@ export default {
   created() {
     getCourseProvisioningMetadata().then(data => {
       this.updateMetadata(data)
-      this.$ready('Create Canvas Course Site')
+      this.$ready()
     })
   },
   methods: {

--- a/src/views/CreateProjectSite.vue
+++ b/src/views/CreateProjectSite.vue
@@ -16,8 +16,6 @@
             :disabled="isCreating"
             hide-details
             maxlength="255"
-            placeholder="Enter a name for your site"
-            required
             variant="outlined"
             @keydown.enter="create"
           />
@@ -28,20 +26,9 @@
       </div>
       <div class="d-flex justify-end">
         <v-btn
-          id="cancel-and-return-to-site-creation"
-          aria-label="Cancel and return to Site Creation Overview"
-          class="mx-1"
-          :disabled="isCreating"
-          type="button"
-          variant="text"
-          @click="cancel"
-        >
-          Cancel
-        </v-btn>
-        <v-btn
           id="create-project-site-button"
           aria-controls="page-reader-alert"
-          class="mr-2"
+          class="mr-1"
           color="primary"
           type="submit"
           :disabled="isCreating || !trim(name)"
@@ -56,6 +43,16 @@
             />
             Creating...
           </span>
+        </v-btn>
+        <v-btn
+          id="cancel-and-return-to-site-creation"
+          aria-label="Cancel and return to Site Creation Overview"
+          :disabled="isCreating"
+          type="button"
+          variant="text"
+          @click="cancel"
+        >
+          Cancel
         </v-btn>
       </div>
     </div>
@@ -79,7 +76,7 @@ export default {
     name: undefined
   }),
   created() {
-    this.$ready('Create bCourses Project Site', 'page-create-project-site-name')
+    this.$ready('page-create-project-site-name')
   },
   methods: {
     cancel() {

--- a/src/views/Error.vue
+++ b/src/views/Error.vue
@@ -63,7 +63,7 @@ export default {
       error || this.applicationState.message
     )
     this.header = show404 ? 'Page Not Found' : 'Uh oh, there was a problem.'
-    this.$ready(this.header)
+    this.$ready()
   }
 }
 </script>

--- a/src/views/Jobs.vue
+++ b/src/views/Jobs.vue
@@ -172,7 +172,7 @@ export default {
     getJobSchedule().then(data => {
       this.jobSchedule = data
       this.refresh(true).then(() => {
-        this.$ready('MU-TH-UR 6000')
+        this.$ready()
       })
     })
   },

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -42,7 +42,7 @@ export default {
   components: {DevAuth},
   created() {
     const showDevAuth = false
-    this.$ready('Welcome. Please log in.')
+    this.$ready()
     return {showDevAuth}
   },
   methods: {

--- a/src/views/Roster.vue
+++ b/src/views/Roster.vue
@@ -167,10 +167,10 @@ export default {
           this.$announcer.polite(this.printButtonTooltip)
         },
         error => this.error = error
-      ).finally(() => this.$ready('Roster'))
+      ).finally(() => this.$ready())
     } else {
       this.error = 'You must be a teacher in this bCourses course to view official student rosters.'
-      this.$ready('Roster')
+      this.$ready()
     }
   },
   methods: {

--- a/src/views/SendWelcomeEmail.vue
+++ b/src/views/SendWelcomeEmail.vue
@@ -231,7 +231,7 @@ export default {
     getMyMailingList().then(
       data => {
         this.updateDisplay(data)
-        this.$ready('Mailing List', 'page-header')
+        this.$ready('page-header')
       }
     )
   },


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-433

Note: the `$ready(...)` util no longer takes screenreader alert arg. We follow the router pattern described in https://github.com/vue-a11y/vue-announcer

cc: @lyttam @pauline2k 