### PR TITLE
RIP-436 Remove the clear icon from roster photos text search field

### DIFF
--- a/src/views/Roster.vue
+++ b/src/views/Roster.vue
@@ -30,7 +30,6 @@
               id="roster-search"
               v-model="search"
               aria-label="Search people by name or SID"
-              clearable
               hide-details
               placeholder="Search People"
               type="search"


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-436