### PR TITLE
RIP-458, split canvas_utils.py into separate site and user utils

### DIFF
--- a/ripley/api/canvas_egrades_export_controller.py
+++ b/ripley/api/canvas_egrades_export_controller.py
@@ -32,7 +32,7 @@ from ripley.externals import canvas
 from ripley.externals.canvas import get_course_sections
 from ripley.externals.redis import enqueue, get_job
 from ripley.lib.berkeley_term import BerkeleyTerm
-from ripley.lib.canvas_utils import get_official_sections, parse_canvas_sis_section_id
+from ripley.lib.canvas_site_utils import get_official_sections, parse_canvas_sis_section_id
 from ripley.lib.egrade_utils import LETTER_GRADES, prepare_egrades_export
 from ripley.lib.http import tolerant_jsonify
 from rq.job import JobStatus

--- a/ripley/api/canvas_site_controller.py
+++ b/ripley/api/canvas_site_controller.py
@@ -31,8 +31,9 @@ from ripley.externals import canvas, data_loch
 from ripley.externals.redis import enqueue, get_job
 from ripley.lib.berkeley_course import sort_course_sections
 from ripley.lib.berkeley_term import BerkeleyTerm
-from ripley.lib.canvas_utils import canvas_section_to_api_json, canvas_site_to_api_json, create_canvas_project_site, \
-    get_official_sections, get_teaching_terms, provision_course_site, update_canvas_sections
+from ripley.lib.canvas_site_utils import canvas_section_to_api_json, canvas_site_to_api_json, \
+    create_canvas_project_site, get_official_sections, get_teaching_terms, provision_course_site, \
+    update_canvas_sections
 from ripley.lib.http import tolerant_jsonify
 from ripley.lib.util import to_bool_or_none
 from ripley.merged.grade_distributions import get_grade_distribution_with_demographics, \

--- a/ripley/api/canvas_user_controller.py
+++ b/ripley/api/canvas_user_controller.py
@@ -29,7 +29,7 @@ from ripley.api.errors import BadRequestError, InternalServerError, ResourceNotF
 from ripley.api.util import canvas_role_required
 from ripley.externals import canvas
 from ripley.externals.data_loch import find_people_by_email, find_people_by_name, find_person_by_uid
-from ripley.lib.canvas_utils import add_user_to_course_section
+from ripley.lib.canvas_user_utils import add_user_to_course_section
 from ripley.lib.http import tolerant_jsonify
 
 

--- a/ripley/api/canvas_utility_controller.py
+++ b/ripley/api/canvas_utility_controller.py
@@ -27,7 +27,7 @@ import re
 from flask import current_app as app, request
 from flask_login import current_user, login_required
 from ripley.api.errors import BadRequestError, InternalServerError
-from ripley.lib.canvas_utils import import_users
+from ripley.lib.canvas_user_utils import import_users
 from ripley.lib.http import tolerant_jsonify
 from ripley.models.user import User
 

--- a/ripley/jobs/add_new_users_job.py
+++ b/ripley/jobs/add_new_users_job.py
@@ -33,7 +33,8 @@ from ripley.externals.data_loch import get_all_active_users
 from ripley.externals.s3 import upload_dated_csv
 from ripley.jobs.base_job import BaseJob
 from ripley.jobs.errors import BackgroundJobError
-from ripley.lib.canvas_utils import csv_row_for_campus_user, uid_from_canvas_login_id
+from ripley.lib.canvas_site_utils import uid_from_canvas_login_id
+from ripley.lib.canvas_user_utils import csv_row_for_campus_user
 
 
 class AddNewUsersJob(BaseJob):

--- a/ripley/jobs/bcourses_provision_site_job.py
+++ b/ripley/jobs/bcourses_provision_site_job.py
@@ -31,7 +31,7 @@ from ripley.externals import canvas
 from ripley.jobs.bcourses_refresh_base_job import BcoursesRefreshBaseJob
 from ripley.jobs.errors import BackgroundJobError
 from ripley.lib.canvas_site_provisioning import process_course_enrollments
-from ripley.lib.canvas_utils import csv_formatted_course_role, parse_canvas_sis_section_id
+from ripley.lib.canvas_site_utils import csv_formatted_course_role, parse_canvas_sis_section_id
 from ripley.lib.sis_import_csv import SisImportCsv
 from ripley.lib.util import utc_now
 from ripley.models.canvas_synchronization import CanvasSynchronization

--- a/ripley/jobs/bcourses_refresh_base_job.py
+++ b/ripley/jobs/bcourses_refresh_base_job.py
@@ -36,13 +36,15 @@ import zipfile
 from flask import current_app as app
 from ripley.externals import canvas
 from ripley.externals.data_loch import get_sections_count
-from ripley.externals.s3 import find_all_dated_csvs, find_last_dated_csv, find_last_dated_csvs, stream_object_text, upload_dated_csv
+from ripley.externals.s3 import find_all_dated_csvs, find_last_dated_csv, find_last_dated_csvs, stream_object_text, \
+    upload_dated_csv
 from ripley.jobs.base_job import BaseJob
 from ripley.lib.berkeley_term import BerkeleyTerm
 from ripley.lib.calnet_utils import get_basic_attributes
 from ripley.lib.canvas_site_provisioning import initialize_recent_updates, process_course_enrollments
-from ripley.lib.canvas_utils import api_formatted_course_role, csv_row_for_campus_user, format_term_enrollments_export, \
-    parse_canvas_sis_section_id, uid_from_canvas_login_id, user_id_from_attributes
+from ripley.lib.canvas_site_utils import api_formatted_course_role, format_term_enrollments_export, \
+    parse_canvas_sis_section_id, uid_from_canvas_login_id
+from ripley.lib.canvas_user_utils import csv_row_for_campus_user, user_id_from_attributes
 from ripley.lib.sis_import_csv import SisImportCsv
 from ripley.lib.util import utc_now
 from ripley.models.canvas_synchronization import CanvasSynchronization

--- a/ripley/jobs/export_term_enrollments_job.py
+++ b/ripley/jobs/export_term_enrollments_job.py
@@ -32,7 +32,7 @@ from ripley.externals.s3 import upload_dated_csv
 from ripley.jobs.base_job import BaseJob
 from ripley.jobs.errors import BackgroundJobError
 from ripley.lib.berkeley_term import BerkeleyTerm
-from ripley.lib.canvas_utils import format_term_enrollments_export
+from ripley.lib.canvas_site_utils import format_term_enrollments_export
 from ripley.lib.util import utc_now
 from ripley.models.canvas_synchronization import CanvasSynchronization
 

--- a/ripley/lib/canvas_site_provisioning.py
+++ b/ripley/lib/canvas_site_provisioning.py
@@ -22,17 +22,19 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
 ENHANCEMENTS, OR MODIFICATIONS.
 """
+
 from datetime import timedelta
 from itertools import groupby
 from operator import itemgetter
 
 from flask import current_app as app
-from ripley.externals.data_loch import get_edo_enrollment_updates, get_edo_instructor_updates, get_section_enrollments, \
-    get_section_instructors, get_sections
+from ripley.externals.data_loch import get_edo_enrollment_updates, get_edo_instructor_updates, \
+    get_section_enrollments, get_section_instructors, get_sections
 from ripley.lib.berkeley_term import BerkeleyTerm
 from ripley.lib.calnet_utils import get_basic_attributes
-from ripley.lib.canvas_utils import csv_formatted_course_role, csv_row_for_campus_user, parse_canvas_sis_section_id, \
-    sis_enrollment_status_to_canvas_course_role, user_id_from_attributes
+from ripley.lib.canvas_site_utils import csv_formatted_course_role, parse_canvas_sis_section_id, \
+    sis_enrollment_status_to_canvas_course_role
+from ripley.lib.canvas_user_utils import csv_row_for_campus_user, user_id_from_attributes
 from ripley.lib.util import utc_now
 
 

--- a/ripley/lib/egrade_utils.py
+++ b/ripley/lib/egrade_utils.py
@@ -26,7 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from flask import current_app as app
 from ripley.api.errors import BadRequestError
 from ripley.externals import canvas, data_loch
-from ripley.lib.canvas_utils import parse_canvas_sis_section_id
+from ripley.lib.canvas_site_utils import parse_canvas_sis_section_id
 
 GRADING_BASIS_CODES = ['CPN', 'DPN', 'EPN', 'ESU', 'PNP', 'SUS']
 LETTER_GRADES = ['A+', 'A', 'A-', 'B+', 'B', 'B-', 'C+', 'C', 'C-', 'D+', 'D', 'D-', 'F']
@@ -114,7 +114,7 @@ def _extract_grades(enrollments):
 
 
 def _get_canvas_course_student_grades(canvas_site_id, section_id, term_id):
-    from ripley.lib.canvas_utils import parse_canvas_sis_section_id
+    from ripley.lib.canvas_site_utils import parse_canvas_sis_section_id
 
     enrollments = data_loch.get_basic_profile_and_grades_per_enrollments(term_id=term_id, section_ids=[section_id])
     loch_enrollments_by_uid = {e['ldap_uid']: e for e in enrollments}

--- a/ripley/merged/roster.py
+++ b/ripley/merged/roster.py
@@ -30,7 +30,7 @@ from flask import current_app as app
 from ripley.externals import canvas
 from ripley.externals.data_loch import get_section_enrollments
 from ripley.externals.s3 import get_signed_urls
-from ripley.lib.canvas_utils import parse_canvas_sis_section_id
+from ripley.lib.canvas_site_utils import parse_canvas_sis_section_id
 
 
 def canvas_site_roster(canvas_site_id):

--- a/ripley/models/mailing_list.py
+++ b/ripley/models/mailing_list.py
@@ -30,7 +30,7 @@ from ripley import db, std_commit
 from ripley.externals import canvas, data_loch
 from ripley.lib.berkeley_term import BerkeleyTerm
 from ripley.lib.canvas_authorization import has_instructing_role, is_project_maintainer, is_project_owner
-from ripley.lib.canvas_utils import canvas_site_to_api_json, extract_berkeley_term_id
+from ripley.lib.canvas_site_utils import canvas_site_to_api_json, extract_berkeley_term_id
 from ripley.lib.mailing_list_utils import send_welcome_emails
 from ripley.lib.util import to_isoformat, utc_now
 from ripley.models.base import Base

--- a/ripley/models/user.py
+++ b/ripley/models/user.py
@@ -174,6 +174,7 @@ class User(UserMixin):
             'canvasSiteName': course.name if course else None,
             'canvasSiteSisCourseId': course.sis_course_id if course else None,
             'canvasSiteUserRoles': [],
+
             'canvasUserId': canvas_user_id,
             'canvasUserAvatarUrl': canvas_user_profile.get('avatar_url'),
             'canvasUserLoginId': canvas_user_profile.get('login_id'),

--- a/tests/test_lib/test_canvas_site_utils.py
+++ b/tests/test_lib/test_canvas_site_utils.py
@@ -23,19 +23,19 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-from ripley.lib import canvas_utils
+from ripley.lib.canvas_site_utils import parse_canvas_sis_section_id, uid_from_canvas_login_id
 
 
 class TestCanvasUtils:
 
     def test_parse_login_id_inactive(self):
-        assert canvas_utils.uid_from_canvas_login_id('666') == {'uid': '666', 'inactivePrefix': False}
-        assert canvas_utils.uid_from_canvas_login_id('inactive-666') == {'uid': '666', 'inactivePrefix': True}
-        assert canvas_utils.uid_from_canvas_login_id('xenomorph') == {'uid': None, 'inactivePrefix': None}
-        assert canvas_utils.uid_from_canvas_login_id('inactive-xenomorph') == {'uid': None, 'inactivePrefix': None}
+        assert uid_from_canvas_login_id('666') == {'uid': '666', 'inactivePrefix': False}
+        assert uid_from_canvas_login_id('inactive-666') == {'uid': '666', 'inactivePrefix': True}
+        assert uid_from_canvas_login_id('xenomorph') == {'uid': None, 'inactivePrefix': None}
+        assert uid_from_canvas_login_id('inactive-xenomorph') == {'uid': None, 'inactivePrefix': None}
 
     def test_parse_canvas_sis_section_id(self):
-        assert canvas_utils.parse_canvas_sis_section_id(None) == (None, None)
-        assert canvas_utils.parse_canvas_sis_section_id('666') == (None, None)
-        assert canvas_utils.parse_canvas_sis_section_id('SEC:2023-B-12345')[0] == '12345'
-        assert canvas_utils.parse_canvas_sis_section_id('SEC:2023-B-12345')[1].to_sis_term_id() == '2232'
+        assert parse_canvas_sis_section_id(None) == (None, None)
+        assert parse_canvas_sis_section_id('666') == (None, None)
+        assert parse_canvas_sis_section_id('SEC:2023-B-12345')[0] == '12345'
+        assert parse_canvas_sis_section_id('SEC:2023-B-12345')[1].to_sis_term_id() == '2232'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-458

Break up the `canvas_utils` monopoly. A fairly simple refactor.