### PR TITLE
RIP-511 Quell the overeager roster photos

### DIFF
--- a/src/components/bcourses/roster/RosterPhoto.vue
+++ b/src/components/bcourses/roster/RosterPhoto.vue
@@ -5,7 +5,6 @@
     :aria-label="`Photo of ${student.firstName} ${student.lastName}`"
     class="photo"
     cover
-    eager
     :lazy-src="photoPlaceholder"
     width="72"
     :src="photoUrl"


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-511

This may not solve all our performance woes, but telling all images in the grid to load enthusiastically and immediately definitely isn't a help.