### PR TITLE
RIP-517, improved UI responsiveness for Roster Photos page

### DIFF
--- a/src/components/bcourses/roster/RosterPhotos.vue
+++ b/src/components/bcourses/roster/RosterPhotos.vue
@@ -1,6 +1,6 @@
 <template>
   <ul
-    class="text-center"
+    class="pa-0 text-center"
     :class="`override-flex-${showOnePhotoPerPage ? 1 : 'all'}`"
     style="display: flex; flex-wrap: wrap; width: 100%; padding-top: 1rem; margin-left: 1rem"
   >

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -78,15 +78,6 @@ export default createVuetify({
     VTextField,
     VTooltip
   },
-  display: {
-    thresholds: {
-      xs: 0,
-      sm: 576,
-      md: 768,
-      lg: 992,
-      xl: 1200
-    }
-  },
   icons: {
     defaultSet: 'mdi',
     aliases,

--- a/src/views/Roster.vue
+++ b/src/views/Roster.vue
@@ -24,12 +24,13 @@
       >
         {{ success }}
       </v-alert>
-      <v-container v-if="!error" fluid>
-        <v-row align-v="center" class="display-none-when-print">
+      <v-container v-if="!error" class="pb-0" fluid>
+        <v-row align="center" class="display-none-when-print" no-gutters>
           <v-col
-            class="pr-2 roster-column-when-print"
-            md="3"
-            sm="12"
+            class="pr-2 pt-1 roster-column-when-print"
+            :lg="size(roster.sections) ? 6 : 8"
+            :md="size(roster.sections) ? 4 : 6"
+            :sm="size(roster.sections) ? 3 : 6"
           >
             <label for="roster-search" class="sr-only">Input automatically searches upon text entry</label>
             <v-text-field
@@ -43,36 +44,39 @@
               variant="outlined"
             />
           </v-col>
-          <v-col md="5" sm="12">
-            <div v-if="roster.sections">
-              <select
-                id="section-select"
-                v-model="selectedSectionId"
-                aria-label="Search specific section (defaults to all sections)"
-                @change="onSelectSection"
+          <v-col
+            v-if="size(roster.sections)"
+            class="pr-2 pt-1 z-index-100"
+            lg="1"
+            md="1"
+            sm="1"
+          >
+            <select
+              id="section-select"
+              v-model="selectedSectionId"
+              aria-label="Search specific section (defaults to all sections)"
+              @change="onSelectSection"
+            >
+              <option :value="null">All Sections</option>
+              <option
+                v-for="(section, index) in roster.sections"
+                :key="index"
+                :value="section.id"
               >
-                <option :value="null">All Sections</option>
-                <option
-                  v-for="(section, index) in roster.sections"
-                  :key="index"
-                  :value="section.id"
-                >
-                  {{ section.name }}
-                </option>
-              </select>
-            </div>
+                {{ section.name }}
+              </option>
+            </select>
           </v-col>
-          <v-col class="pt-3" md="4" sm="12">
-            <div class="d-flex flex-wrap float-right">
+          <v-col class="pt-1" xs="12">
+            <div class="d-flex flex-nowrap float-right">
               <div class="pr-2">
                 <v-btn
                   id="download-csv"
                   :disabled="isDownloading || !students.length"
-                  size="large"
                   variant="outlined"
                   @click="downloadCsv"
                 >
-                  <v-icon class="pr-2" :icon="mdiDownload" />
+                  <v-icon class="pr-2" :icon="mdiDownload" size="large" />
                   Export<span class="sr-only"> CSV file</span>
                 </v-btn>
               </div>
@@ -90,11 +94,10 @@
                       id="print-roster"
                       color="primary"
                       :disabled="disablePrintButton"
-                      size="large"
                       v-bind="props"
                       @click="printRoster"
                     >
-                      <v-icon class="pr-2 text-white" :icon="mdiPrinter" />
+                      <v-icon class="pr-2 text-white" :icon="mdiPrinter" size="large" />
                       Print<span class="sr-only"> roster of students</span>
                     </v-btn>
                   </template>
@@ -103,37 +106,47 @@
             </div>
           </v-col>
         </v-row>
-        <v-row no-gutters class="display-none-when-print" justify="end">
-          <div class="d-flex flex-wrap float-right pr-2">
-            <v-checkbox
-              v-model="showOnePhotoPerPage"
-              label="Print one student per page"
-              density="comfortable"
+        <v-row
+          class="display-none-when-print"
+          justify="center"
+          no-gutters
+        >
+          <v-col align-self="center">
+            <div
+              aria-live="polite"
+              class="display-none-when-print text-subtitle-2"
+              role="alert"
             >
-            </v-checkbox>
-          </div>
-        </v-row>
-        <v-row v-if="students.length">
-          <v-col role="alert" aria-live="polite" class="py-1 display-none-when-print">{{ pluralize('student', students.length, {0: 'No', 1: 'One'}) }} found</v-col>
-        </v-row>
-        <v-row no-gutters>
-          <v-col sm="12">
-            <RosterPhotos
-              v-if="students.length"
-              :students="students"
-              :show-one-photo-per-page="showOnePhotoPerPage"
-            />
-            <div v-if="!roster.students.length" role="alert" aria-live="polite">
-              <v-icon class="icon-gold" :icon="mdiAlertCircleOutline" />
-              Students have not yet signed up for this class.
+              {{ pluralize('student', students.length, {0: 'No', 1: 'One'}) }} found
             </div>
-            <div v-if="roster.students.length && !students.length" role="alert" aria-live="polite">
-              <v-icon class="icon-gold" :icon="mdiAlertCircleOutline" />
-              No students found matching your query.
+          </v-col>
+          <v-col>
+            <div class="float-right">
+              <v-checkbox
+                v-model="showOnePhotoPerPage"
+                density="comfortable"
+                hide-details
+                label="Print one student per page"
+              />
             </div>
           </v-col>
         </v-row>
+        <v-row v-if="students.length" no-gutters>
+        </v-row>
       </v-container>
+      <RosterPhotos
+        v-if="students.length"
+        :students="students"
+        :show-one-photo-per-page="showOnePhotoPerPage"
+      />
+      <div v-if="!roster.students.length" role="alert" aria-live="polite">
+        <v-icon class="icon-gold" :icon="mdiAlertCircleOutline" />
+        Students have not yet signed up for this class.
+      </div>
+      <div v-if="roster.students.length && !students.length" role="alert" aria-live="polite">
+        <v-icon class="icon-gold" :icon="mdiAlertCircleOutline" />
+        No students found matching your query.
+      </div>
     </div>
   </div>
 </template>
@@ -142,13 +155,14 @@
 import Header1 from '@/components/utils/Header1.vue'
 import RosterPhotos from '@/components/bcourses/roster/RosterPhotos'
 import {mdiAlertCircleOutline, mdiDownload, mdiPrinter} from '@mdi/js'
+import {pluralize} from '@/utils'
 </script>
 
 <script>
 import Context from '@/mixins/Context'
 import {each, filter, map, size, trim} from 'lodash'
 import {exportRoster, getRoster} from '@/api/canvas-site'
-import {printPage, pluralize} from '@/utils'
+import {printPage} from '@/utils'
 
 export default {
   name: 'Roster',
@@ -232,7 +246,6 @@ export default {
     idx(value) {
       return value && trim(value).replace(/[^\w\s]/gi, '').toLowerCase()
     },
-    pluralize,
     printRoster() {
       printPage(`${this.idx(this.currentUser.canvasSiteName).replace(/\s/g, '-')}_roster`)
     }
@@ -243,6 +256,9 @@ export default {
 <style scoped lang="scss">
 select {
   height: 44px;
+}
+.z-index-100 {
+  z-index: 100;
 }
 @media print {
   .roster-column-when-print {


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-517

Ripley runs in a narrow viewport (ie, an iframe). Yes we want Vuetify grid layouts to wrap but not prematurely. I removed our custom grid display thresholds config and gave the Roster page smarter column widths (using the v-col props 'sm', 'md', etc.)