### PR TITLE
[QA] RIP-514: removes 'LTI 1.3' from roster photos name

### DIFF
--- a/ripley/lib/canvas_lti.py
+++ b/ripley/lib/canvas_lti.py
@@ -116,7 +116,7 @@ def lti_tool_definitions():
                 'placement': 'account_navigation',
             },
             'roster_photos': {
-                'name': 'Roster Photos (LTI 1.3)',
+                'name': 'Roster Photos',
                 'account_id': app.config['CANVAS_COURSES_ACCOUNT_ID'],
                 'client_id': '10720000000000628',
                 'description': 'Browse and search official roster photos',

--- a/tests/test_api/test_lti_controller.py
+++ b/tests/test_api/test_lti_controller.py
@@ -140,7 +140,7 @@ class TestGetRosterPhotosConfig:
             app,
             config_uri='roster_photos.json',
             target='launch_roster_photos',
-            expected_title='Roster Photos (LTI 1.3)',
+            expected_title='Roster Photos',
             expected_description='Browse and search official roster photos',
             expected_placement='course_navigation',
         )


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-514

dev PR is #631 