### PR TITLE
RIP-556 add underlines to a hrefs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -95,7 +95,6 @@ const context = useContextStore()
 }
 a {
   color: $color-primary-text;
-  text-decoration: none;
   &:hover {
     cursor: pointer;
   }

--- a/src/views/CourseGradeExport.vue
+++ b/src/views/CourseGradeExport.vue
@@ -41,9 +41,7 @@
                 id="canvas-course-settings-href"
                 :href="`${config.canvasApiUrl}/courses/${currentUser.canvasSiteId}/settings#tab-details`"
                 target="_top"
-              >
-                Course Settings
-              </a>
+              >Course Settings</a>
             </span>
             <span v-if="noGradingStandardEnabled">
               Set a grading scheme in
@@ -51,9 +49,7 @@
                 id="canvas-course-settings-href"
                 :href="`${config.canvasApiUrl}/courses/${currentUser.canvasSiteId}/settings#tab-details`"
                 target="_top"
-              >
-                Course Settings
-              </a>
+              >Course Settings</a>
               and return once completed.
             </span>
             <div class="pt-1">


### PR DESCRIPTION
https://jira-secure.berkeley.edu/projects/RIP/issues/RIP-556

I realize this style change impacts multiple views, but I assume the accessibility issue impacting egrades also impacts roster photos, so this will address both.

Not sure if my html changes in CourseGradeExport.vue are kosher, but they linted, and the other way was giving me trailing underlined spaces after the URL.