### PR TITLE
RIP-588, if error in db.commit then log exception before re-raise

### DIFF
--- a/ripley/__init__.py
+++ b/ripley/__init__.py
@@ -54,7 +54,8 @@ def std_commit(allow_test_environment=False):
     try:
         db.session.commit()
         successful_commit = True
-    except SQLAlchemyError:
+    except SQLAlchemyError as e:
+        app.logger.exception(e)
         db.session.rollback()
         raise
     finally:


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-588

Log exception to `ripley.log` so we can see it in context of previous events.