### PR TITLE
RIP-603, finish up test coverage on person-to-add

### DIFF
--- a/ripley/api/error_handlers.py
+++ b/ripley/api/error_handlers.py
@@ -29,30 +29,41 @@ from ripley.lib.http import tolerant_jsonify
 
 @app.errorhandler(ripley.api.errors.BadRequestError)
 def handle_bad_request(error):
-    return error.to_json(), 400
+    return _to_api_json(error), 400
 
 
 @app.errorhandler(ripley.api.errors.UnauthorizedRequestError)
 def handle_unauthorized(error):
-    return error.to_json(), 401
+    return _to_api_json(error), 401
 
 
 @app.errorhandler(ripley.api.errors.ForbiddenRequestError)
 def handle_forbidden(error):
-    return error.to_json(), 403
+    return _to_api_json(error), 403
 
 
 @app.errorhandler(ripley.api.errors.ResourceNotFoundError)
 def handle_resource_not_found(error):
-    return error.to_json(), 404
+    return _to_api_json(error), 404
 
 
 @app.errorhandler(ripley.api.errors.InternalServerError)
 def handle_internal_server_error(error):
-    return error.to_json(), 500
+    return _to_api_json(error), 500
 
 
 @app.errorhandler(Exception)
 def handle_unexpected_error(error):
     app.logger.exception(error)
     return tolerant_jsonify({'message': 'An unexpected server error occurred.'}), 500
+
+
+def _to_api_json(error):
+    if app.config['TESTING'] and hasattr(error, 'message') and error.message:
+        app.logger.error(f"""
+            ----------------------------------------------------------------
+
+            {error.message}
+
+            ----------------------------------------------------------------""")
+    return error.to_json()

--- a/src/api/canvas-user.ts
+++ b/src/api/canvas-user.ts
@@ -1,7 +1,7 @@
 import utils from '@/api/api-utils'
 
 export function addUser(canvasSiteId: number, uid: string, sectionId: string, role: string) {
-  return utils.post(`/api/canvas_user/${canvasSiteId}/users`, {uid, sectionId, role}, false)
+  return utils.post(`/api/canvas_user/${canvasSiteId}/add_user`, {uid, sectionId, role}, false)
 }
 
 export function getSections(canvasSiteId: number) {

--- a/tests/fixtures/canvas/json/account.json
+++ b/tests/fixtures/canvas/json/account.json
@@ -1779,6 +1779,22 @@
                     "name": "UC Berkeley",
                     "workflow_state": "active"
                 }
+            },
+            {
+                "id": 568,
+                "role": "StudentEnrollment",
+                "label": "Student",
+                "last_updated_at": "2023-09-02T18:11:38Z",
+                "base_role_type": "StudentEnrollment",
+                "workflow_state": "active",
+                "created_at": "2020-09-09T17:04:57-07:00",
+                "permissions": {},
+                "is_account_role": "true",
+                "account": {
+                    "id": 90242,
+                    "name": "UC Berkeley",
+                    "workflow_state": "active"
+                }
             }
         ]
     },

--- a/tests/fixtures/canvas/json/course.json
+++ b/tests/fixtures/canvas/json/course.json
@@ -121,6 +121,36 @@
         },
         "status_code": 200
     },
+    "get_enrollments_3030303_4567890": {
+        "method": "GET",
+        "endpoint": "courses/3030303/users/4567890?include=enrollments",
+        "data": {
+            "id": 4567890,
+            "name": "Ash 🤖",
+            "short_name": "Ash 🤖",
+            "sortable_name": "🤖, Ash",
+            "integration_id": null,
+            "login_id": "30000",
+            "sis_user_id": "300300000",
+            "enrollments": [
+                {
+                    "id": 101,
+                    "user_id": 4567890,
+                    "course_id": 3030303,
+                    "course_section_id": 10000,
+                    "type": "TeacherEnrollment",
+                    "enrollment_state": "active",
+                    "role": "TeacherEnrollment",
+                    "last_activity_at": "2023-03-02T06:04:43Z",
+                    "sis_user_id": "300300000",
+                    "sis_course_id": "CRS:ANTHRO-189-2023-B",
+                    "sis_section_id": "2023-B-32936",
+                    "html_url": "https://ucberkeley.beta.instructure.com/courses/3030303/users/4567890"
+                }
+            ]
+        },
+        "status_code": 200
+    },
     "get_enrollments_8876542_4567890": {
         "method": "GET",
         "endpoint": "courses/8876542/users/4567890?include=enrollments",
@@ -478,6 +508,11 @@
             "nonxlist_course_id": null
           }
         ]
+    },
+    "get_sections_3030303": {
+        "method": "GET",
+        "endpoint": "courses/3030303/sections",
+        "data": []
     },
     "get_sections_8876542": {
         "method": "GET",
@@ -1565,6 +1600,23 @@
             "enrollment_state": "active",
             "role": "TeacherEnrollment",
             "last_activity_at": "2023-03-02T06:04:43Z",
+            "sis_user_id": "300300000",
+            "html_url": "https://ucberkeley.beta.instructure.com/courses/1234567/users/4567890"
+        },
+        "status_code": 200
+    },
+    "post_course_enrollments_8876542": {
+        "method": "POST",
+        "endpoint": "courses/8876542/enrollments",
+        "data": {
+            "user_id": 4567890,
+            "course_id": 8876542,
+            "course_section_id": null,
+            "type": "TeacherEnrollment",
+            "enrollment_state": "active",
+            "role": "TeacherEnrollment",
+            "last_activity_at": "2023-03-02T06:04:43Z",
+            "role_id": 12345,
             "sis_user_id": "300300000",
             "html_url": "https://ucberkeley.beta.instructure.com/courses/1234567/users/4567890"
         },

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands = npm run lint-vue-fix {posargs}
 commands = npm run build-vue
 
 [testenv:test]
-commands = pytest --durations=3 {posargs: tests}
+commands = pytest --durations=3 -W ignore::DeprecationWarning {posargs: tests}
 
 [testenv:lint-py]
 # Bottom of file has Flake8 settings


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-603

The change in `ripley/api/error_handlers.py` means we get more error info on the command line, when running pytest. I also disabled deprecation warnings via `tox.ini`.