### PR TITLE
RIP-619: tweaks language in grade distribution descriptions

### DIFF
--- a/src/components/bcourses/analytics/DemographicsChart.vue
+++ b/src/components/bcourses/analytics/DemographicsChart.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="grade-distribution-demographics pa-5">
-    <h2 id="grade-distribution-demographics-header">Grade Point Average by Demographics</h2>
+    <h2 id="grade-distribution-demographics-header">Grade Average by Demographics</h2>
     <div>
-      The grade point average (GPA) chart displays the available GPA at the end of the current
-      and previous semesters. Select a demographic to compare trending GPA results.
+      The grade average chart displays the class average grade point equivalent at the end of the current
+      and prior semesters. Select a demographic to compare average grade point trends.
     </div>
     <select
       id="grade-distribution-demographics-select"
@@ -50,21 +50,21 @@
             <thead class="bg-grey-lighten-4">
               <tr>
                 <th class="font-weight-bold pl-4 py-2" scope="col">Semester</th>
-                <th class="font-weight-bold py-2" scope="col">Overall Class Grade Average</th>
-                <th class="font-weight-bold py-2" scope="col">Overall Class Count</th>
+                <th class="font-weight-bold py-2" scope="col">Class Grade Average</th>
+                <th class="font-weight-bold py-2" scope="col">Class Grade Count</th>
                 <th
                   v-if="size(chartSettings.series) > 1"
                   class="font-weight-bold py-2"
                   scope="col"
                 >
-                  Average {{ chartSettings.series[1].name }}
+                  {{ selectedDemographicLabel }} Grade Average
                 </th>
                 <th
                   v-if="size(chartSettings.series) > 1"
                   class="font-weight-bold py-2"
                   scope="col"
                 >
-                  Count of {{ chartSettings.series[1].name }}
+                  {{ selectedDemographicLabel }} Grade Count
                 </th>
               </tr>
             </thead>
@@ -174,6 +174,12 @@ export default {
     selectedDemographic: null,
     showTable: false
   }),
+  computed: {
+    selectedDemographicLabel() {
+      const group = get(this.selectedDemographic, 'group')
+      return `${get(this.demographicOptions, group)['label']}`
+    }
+  },
   watch: {
     isDemoMode() {
       this.setTooltipFormatter()
@@ -185,7 +191,7 @@ export default {
     this.chartSettings.legend.squareSymbol = false
     this.chartSettings.legend.symbolHeight = 3
     this.chartSettings.plotOptions.series.lineWidth = 3
-    this.chartSettings.title.text = 'Overall Class Grade Average by Semester'
+    this.chartSettings.title.text = 'Class Grade Average by Semester'
     this.chartSettings.yAxis.labels.format = '{value:.1f}'
     this.chartSettings.yAxis.max = 4
     this.chartSettings.yAxis.min = 0
@@ -247,7 +253,7 @@ export default {
           data: [],
           legendSymbol: 'rectangle',
           marker: this.getSeriesMarker(this.colors.secondary),
-          name: `${get(this.demographicOptions, group)['label']} Grades`
+          name: `${this.selectedDemographicLabel} Grades`
         }
         each(this.gradeDistribution, item => {
           const value = get(item, `${group}.${option}`) || get(item, `${group}`)

--- a/src/components/bcourses/analytics/PriorEnrollmentChart.vue
+++ b/src/components/bcourses/analytics/PriorEnrollmentChart.vue
@@ -3,9 +3,9 @@
     <div class="pl-3">
       <h2 id="grade-distribution-enrollment-header">Grade Distribution by Prior Class Enrollment</h2>
       <div>
-        The distribution chart displays available grades at the end of the current and previous semesters.
-        Search prerequisite courses to compare side-by-side final grade results of students taking this course and
-        those who have taken selected previous course enrollments.
+        The grade distribution chart displays available grades at the end of the current and prior semesters.
+        Search for a prerequisite course to compare side-by-side final grades of all students taking this course and
+        those who have taken the prerequisite.
       </div>
       <div class="d-flex justify-space-between">
         <div class="d-flex align-center">

--- a/src/views/CourseGradeDistribution.vue
+++ b/src/views/CourseGradeDistribution.vue
@@ -28,7 +28,7 @@
         The Grade Distribution dashboard is an informational tool to assist instructors in assessing student performance
         based on existing bCourses class grades and historical trends. Only you can view this information developed
         specifically for your class. Please use the <a id="newt-feedback-link" :href="config.newtFeedbackFormUrl" target="_blank">feedback form</a>
-        for any questions, feedback, or to suggest additional methods of displaying grade reporting.
+        to ask questions, submit feedback, or suggest additional methods of displaying grade reporting.
       </p>
       <v-alert
         v-if="errorMessage"


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-619

"Prior" is more plural than "previous", right? The latter sounds like only one.