### PR TITLE
RIP-650, Redis cache for API /egrades_export/is_official_course without login required

### DIFF
--- a/ripley/api/canvas_utility_controller.py
+++ b/ripley/api/canvas_utility_controller.py
@@ -36,6 +36,7 @@ from ripley.models.user import User
 
 @app.route('/api/canvas/external_tools')
 def get_external_tools():
+    # Used by canvas-customization.js
     cache_key = 'canvas_external_tools'
     api_json = fetch_cached_dict_object(cache_key)
     if not api_json:


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-650

This API endpoint is used by `canvas-customization.js` and thus the bug: unexpected 401 auth fail. I removed `@login_required` and added Redis caching to lessen load.