### PR TITLE
RIP-613: reorgs CSVs in S3

### DIFF
--- a/ripley/externals/s3.py
+++ b/ripley/externals/s3.py
@@ -166,7 +166,7 @@ def stream_object_text(object_key, bucket=None):
 
 def upload_dated_csv(local_name, remote_name, folder, timestamp):
     with open(local_name, mode='rb') as f:
-        return put_binary_data_to_s3(f'{folder}/{timestamp[0:4]}/{timestamp[5:7]}/{timestamp}-{remote_name}.csv', f, 'text/csv')
+        return put_binary_data_to_s3(f'{folder}/{timestamp[0:4]}/{timestamp[5:7]}/{remote_name}-{timestamp}.csv', f, 'text/csv')
 
 
 def _get_s3_client():

--- a/ripley/jobs/add_guest_users_job.py
+++ b/ripley/jobs/add_guest_users_job.py
@@ -75,7 +75,7 @@ class AddGuestUsersJob(BaseJob):
                 raise BackgroundJobError('New users import failed.')
 
         # Archive import file in S3.
-        upload_dated_csv(canvas_import_file.name, 'guest-import', 'canvas_sis_imports', this_sync.strftime('%F_%H-%M-%S'))
+        upload_dated_csv(canvas_import_file.name, 'guest-users', 'canvas-sis-imports', this_sync.strftime('%F_%H-%M-%S'))
         CanvasSynchronization.update(guests=this_sync)
 
         app.logger.info('Users added, job complete.')

--- a/ripley/jobs/add_new_users_job.py
+++ b/ripley/jobs/add_new_users_job.py
@@ -75,8 +75,8 @@ class AddNewUsersJob(BaseJob):
                     raise BackgroundJobError('New users import failed.')
 
             # Archive export and import files in S3.
-            upload_dated_csv(canvas_export_file.name, 'user-provision-report', 'canvas_provisioning_reports', timestamp)
-            upload_dated_csv(canvas_import_file.name, 'user-sis-import', 'canvas_sis_imports', timestamp)
+            upload_dated_csv(canvas_export_file.name, 'provisioned-users', 'canvas-provisioning-reports', timestamp)
+            upload_dated_csv(canvas_import_file.name, 'user-provision', 'canvas-sis-imports', timestamp)
             app.logger.info('Users added, job complete.')
 
     @classmethod

--- a/ripley/jobs/compare_sis_import_csvs.py
+++ b/ripley/jobs/compare_sis_import_csvs.py
@@ -130,22 +130,22 @@ def _collect_csv_keys(days_ago): # noqa C901
             elif f'enrollments-{term_id}-update' in junction_csvs:
                 junction_csvs[f'enrollments-{term_id}-update'].append(key)
 
-    for key in s3.iterate_monthly_folder('canvas_provisioning_reports'):
+    for key in s3.iterate_monthly_folder('canvas-provisioning-reports'):
         if not _within_daily_window(key, days_ago):
             continue
-        if 'user-provision-report' in key:
+        if 'provisioned-users' in key:
             ripley_csvs['users-initial'].append(key)
         elif 'enrollments-export' in key:
             term_id = _get_term_id(key)
             if term_id:
                 ripley_csvs[f'enrollments-{term_id}-initial'].append(key)
 
-    for key in s3.iterate_monthly_folder('canvas_sis_imports'):
+    for key in s3.iterate_monthly_folder('canvas-sis-imports'):
         if not _within_daily_window(key, days_ago):
             continue
-        if 'user-sis-import' in key:
+        if 'user-provision' in key:
             ripley_csvs['users-update'].append(key)
-        elif 'sis-id-sis-import' in key:
+        elif 'sis-ids' in key:
             ripley_csvs['sis-ids-update'].append(key)
         elif 'enrollments-TERM' in key and 'sis-import' in key:
             term_id = _get_term_id(key)

--- a/ripley/jobs/export_term_enrollments_job.py
+++ b/ripley/jobs/export_term_enrollments_job.py
@@ -92,7 +92,7 @@ class ExportTermEnrollmentsJob(BaseJob):
                 if not upload_dated_csv(
                     export_file.name,
                     format_term_enrollments_export(sis_term_id),
-                    'canvas_provisioning_reports',
+                    'canvas-provisioning-reports',
                     this_sync.strftime('%F_%H-%M-%S'),
                 ):
                     raise BackgroundJobError('New users import failed.')

--- a/ripley/jobs/lti_usage_report_job.py
+++ b/ripley/jobs/lti_usage_report_job.py
@@ -108,9 +108,9 @@ class LtiUsageReportJob(BaseJob):
                     'Courses Visible': courses_count,
                 })
 
-        summary_report_filename = f"lti_usage_summary-{sis_term_id.replace('TERM:', '')}-{datetime.now().strftime('%F')}.csv"
+        summary_report_filename = f"lti-usage-summary-{sis_term_id.replace('TERM:', '')}-{datetime.now().strftime('%F')}.csv"
         with open(tmpfile.name, mode='rb') as f:
-            return put_binary_data_to_s3(f'lti_usage_reports/{summary_report_filename}', f, 'text/csv')
+            return put_binary_data_to_s3(f'lti-usage-reports/{summary_report_filename}', f, 'text/csv')
 
     def generate_courses_report(self, sis_term_id):
         tmpfile = tempfile.NamedTemporaryFile()
@@ -129,9 +129,9 @@ class LtiUsageReportJob(BaseJob):
                         'Email': teacher and getattr(teacher, 'email', None),
                     })
 
-        courses_report_filename = f"lti_usage_courses-{sis_term_id.replace('TERM:', '')}-{datetime.now().strftime('%F')}.csv"
+        courses_report_filename = f"lti-usage-courses-{sis_term_id.replace('TERM:', '')}-{datetime.now().strftime('%F')}.csv"
         with open(tmpfile.name, mode='rb') as f:
-            return put_binary_data_to_s3(f'lti_usage_reports/{courses_report_filename}', f, 'text/csv')
+            return put_binary_data_to_s3(f'lti-usage-reports/{courses_report_filename}', f, 'text/csv')
 
     def merge_course_occurrence(self, course, tool_url):
         course_id = course['canvas_site_id']

--- a/ripley/lib/canvas_site_utils.py
+++ b/ripley/lib/canvas_site_utils.py
@@ -135,7 +135,7 @@ def extract_berkeley_term_id(canvas_site):
 
 
 def format_term_enrollments_export(term_id):
-    return f"{term_id.replace(':', '-')}-term-enrollments-export"
+    return f"enrollments-{term_id.replace(':', '-')}"
 
 
 def get_canvas_course_id(course_slug):
@@ -321,8 +321,8 @@ def update_canvas_sections(course, all_section_ids, section_ids_to_remove):
 
         upload_dated_csv(
             sections_csv.tempfile.name,
-            f"course-provision-{canvas_sis_term_id.replace(':', '-')}-{course.sis_course_id.replace(':', '-')}-sections-sis-import",
-            'canvas_sis_imports',
+            f"course-provision-sections-{course.sis_course_id.replace(':', '-')}",
+            'canvas-sis-imports',
             utc_now().strftime('%F_%H-%M-%S'),
         )
 

--- a/ripley/lib/canvas_user_utils.py
+++ b/ripley/lib/canvas_user_utils.py
@@ -123,8 +123,8 @@ def import_users(uids):
 
         upload_dated_csv(
             users_csv.tempfile.name,
-            'user-provision-sis-import',
-            'canvas_sis_imports',
+            'user-provision',
+            'canvas-sis-imports',
             utc_now().strftime('%F_%H-%M-%S'),
         )
 

--- a/ripley/lib/course_site_provisioner.py
+++ b/ripley/lib/course_site_provisioner.py
@@ -72,8 +72,8 @@ def provision_course_site(uid, site_name, site_abbreviation, term_slug, section_
         course_csv.filehandle.close()
         upload_dated_csv(
             course_csv.tempfile.name,
-            f"course-provision-{sis_course_id.replace(':', '-')}-course-sis-import",
-            'canvas_sis_imports',
+            f"course-provision-{sis_course_id.replace(':', '-')}",
+            'canvas-sis-imports',
             utc_now().strftime('%F_%H-%M-%S'),
         )
         app.logger.debug(f'Posting course SIS import (sis_course_id={sis_course_id}).')
@@ -124,8 +124,8 @@ def provision_course_site(uid, site_name, site_abbreviation, term_slug, section_
         sections_csv.filehandle.close()
         upload_dated_csv(
             sections_csv.tempfile.name,
-            f"course-provision-{course.sis_course_id.replace(':', '-')}-sections-sis-import",
-            'canvas_sis_imports',
+            f"course-provision-sections-{course.sis_course_id.replace(':', '-')}",
+            'canvas-sis-imports',
             utc_now().strftime('%F_%H-%M-%S'),
         )
         app.logger.debug(f'Posting course sections SIS import (canvas_site_id={course.id}).')

--- a/tests/test_jobs/test_add_guest_users_job.py
+++ b/tests/test_jobs/test_add_guest_users_job.py
@@ -62,7 +62,7 @@ class TestAddNewUsersJob:
 
             with mock_s3_bucket(app) as s3:
                 AddGuestUsersJob(app)._run()
-                users_imported = read_s3_csv(app, s3, 'guest-import')
+                users_imported = read_s3_csv(app, s3, 'guest-users')
                 assert len(users_imported) == 2
                 assert users_imported[0] == 'user_id,login_id,first_name,last_name,email,status'
                 assert users_imported[1] == 'UID:9999999,9999999,Jonesy,🐈,jonesy@berkeley.edu,active'

--- a/tests/test_jobs/test_add_new_users_job.py
+++ b/tests/test_jobs/test_add_new_users_job.py
@@ -52,10 +52,10 @@ class TestAddNewUsersJob:
 
             with mock_s3_bucket(app) as s3:
                 AddNewUsersJob(app)._run()
-                provisioning_report = read_s3_csv(app, s3, 'user-provision-report')
+                provisioning_report = read_s3_csv(app, s3, 'provisioned-users')
                 assert len(provisioning_report) == 4
 
-                users_imported = read_s3_csv(app, s3, 'user-sis-import')
+                users_imported = read_s3_csv(app, s3, 'user-provision')
                 assert len(users_imported) == 6
                 assert users_imported[0] == 'user_id,login_id,first_name,last_name,email,status'
                 assert users_imported[1] == 'UID:10000,10000,Ellen,Ripley,ellen.ripley@berkeley.edu,active'

--- a/tests/test_jobs/test_bcourses_delete_email_addresses_job.py
+++ b/tests/test_jobs/test_bcourses_delete_email_addresses_job.py
@@ -35,13 +35,13 @@ class TestBcoursesDeleteEmailAddressesJob:
     def test_no_changes(self, app):
         with setup_bcourses_refresh_job(app) as (s3, m):
             BcoursesDeleteEmailAddressesJob(app)._run()
-            assert_s3_key_not_found(app, s3, 'sis-id-sis-import')
-            assert_s3_key_not_found(app, s3, 'user-sis-import')
+            assert_s3_key_not_found(app, s3, 'sis-ids')
+            assert_s3_key_not_found(app, s3, 'user-provision')
 
     def test_no_enrollments_in_inactivate_job(self, app):
         with setup_bcourses_refresh_job(app) as (s3, m):
             BcoursesDeleteEmailAddressesJob(app)._run()
-            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B-sis-import')
+            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B')
 
     @mock.patch('ripley.lib.calnet_utils.get_calnet_attributes_for_uids')
     @mock.patch('ripley.lib.calnet_utils.get_users')
@@ -54,8 +54,8 @@ class TestBcoursesDeleteEmailAddressesJob:
 
             BcoursesDeleteEmailAddressesJob(app)._run()
 
-            assert_s3_key_not_found(app, s3, 'sis-id-sis-import')
-            assert_s3_key_not_found(app, s3, 'user-sis-import')
+            assert_s3_key_not_found(app, s3, 'sis-ids')
+            assert_s3_key_not_found(app, s3, 'user-provision')
             assert next(r for r in m.request_history if r.method == 'DELETE' and 'users/4567890/communication_channels' in r.url)
 
     @pytest.fixture(scope='function')

--- a/tests/test_jobs/test_bcourses_inactivate_accounts_job.py
+++ b/tests/test_jobs/test_bcourses_inactivate_accounts_job.py
@@ -35,13 +35,13 @@ class TestBcoursesInactivateAccountsJob:
     def test_no_changes(self, app):
         with setup_bcourses_refresh_job(app) as (s3, m):
             BcoursesInactivateAccountsJob(app)._run()
-            assert_s3_key_not_found(app, s3, 'sis-id-sis-import')
-            assert_s3_key_not_found(app, s3, 'user-sis-import')
+            assert_s3_key_not_found(app, s3, 'sis-ids')
+            assert_s3_key_not_found(app, s3, 'user-provision')
 
     def test_no_enrollments_in_inactivate_job(self, app):
         with setup_bcourses_refresh_job(app) as (s3, m):
             BcoursesInactivateAccountsJob(app)._run()
-            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B-sis-import')
+            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B')
 
     @mock.patch('ripley.lib.calnet_utils.get_calnet_attributes_for_uids')
     @mock.patch('ripley.lib.calnet_utils.get_users')
@@ -54,12 +54,12 @@ class TestBcoursesInactivateAccountsJob:
 
             BcoursesInactivateAccountsJob(app)._run()
 
-            sis_id_changes_imported = read_s3_csv(app, s3, 'sis-id-sis-import')
+            sis_id_changes_imported = read_s3_csv(app, s3, 'sis-ids')
             assert len(sis_id_changes_imported) == 2
             assert sis_id_changes_imported[0] == 'old_id,new_id,old_integration_id,new_integration_id,type'
             assert sis_id_changes_imported[1] == '30030000,UID:30000,,,user'
 
-            user_changes_imported = read_s3_csv(app, s3, 'user-sis-import')
+            user_changes_imported = read_s3_csv(app, s3, 'user-provision')
             assert len(user_changes_imported) == 2
             assert user_changes_imported[0] == 'user_id,login_id,first_name,last_name,email,status'
             assert user_changes_imported[1] == 'UID:30000,30000,Ash,🤖,,suspended'

--- a/tests/test_jobs/test_bcourses_provision_site_job.py
+++ b/tests/test_jobs/test_bcourses_provision_site_job.py
@@ -50,7 +50,7 @@ class TestBcoursesProvisionSiteJob:
         }
         with setup_bcourses_provision_job(app) as (s3, m):
             BcoursesProvisionSiteJob(app)._run(params)
-            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full-sis-import')
+            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full')
             assert len(spring_2023_enrollments_imported) == 4
             assert spring_2023_enrollments_imported[1] == 'CRS:ANTHRO-189-2023-B,30040000,student,SEC:2023-B-32936,active,'
 
@@ -64,7 +64,7 @@ class TestBcoursesProvisionSiteJob:
         }
         with setup_bcourses_provision_job(app) as (s3, m):
             BcoursesProvisionSiteJob(app)._run(params)
-            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B-full-sis-import')
+            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B-full')
 
     @mock.patch('ripley.lib.canvas_site_provisioning.get_section_enrollments')
     def test_added_section(self, mock_section_enrollments, app, section_enrollments):
@@ -88,7 +88,7 @@ class TestBcoursesProvisionSiteJob:
 
         with setup_bcourses_provision_job(app) as (s3, m):
             BcoursesProvisionSiteJob(app)._run(params)
-            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full-sis-import')
+            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full')
             assert len(spring_2023_enrollments_imported) == 7
             new_enrollment = next(e for e in spring_2023_enrollments_imported if '30030000' in e)
             assert new_enrollment == 'CRS:ASTRON-218-2023-B,30030000,student,SEC:2023-B-87654,active,'
@@ -107,7 +107,7 @@ class TestBcoursesProvisionSiteJob:
 
         with setup_bcourses_provision_job(app) as (s3, m):
             BcoursesProvisionSiteJob(app)._run(params)
-            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full-sis-import')
+            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full')
             assert len(spring_2023_enrollments_imported) == 9
             deleted_enrollments = [row for row in spring_2023_enrollments_imported if 'SEC:2023-B-32936' in row]
             updated_enrollments = [row for row in spring_2023_enrollments_imported if 'SEC:2023-B-32937' in row]

--- a/tests/test_jobs/test_bcourses_refresh_accounts_job.py
+++ b/tests/test_jobs/test_bcourses_refresh_accounts_job.py
@@ -35,8 +35,8 @@ class TestBcoursesRefreshAccountsJob:
     def test_no_changes(self, app):
         with setup_bcourses_refresh_job(app) as (s3, m):
             BcoursesRefreshAccountsJob(app)._run()
-            assert_s3_key_not_found(app, s3, 'sis-id-sis-import')
-            assert_s3_key_not_found(app, s3, 'user-sis-import')
+            assert_s3_key_not_found(app, s3, 'sis-ids')
+            assert_s3_key_not_found(app, s3, 'user-provision')
 
     @mock.patch('ripley.lib.calnet_utils.get_users')
     def test_name_change(self, mock_users, app, campus_users):
@@ -49,9 +49,9 @@ class TestBcoursesRefreshAccountsJob:
 
             BcoursesRefreshAccountsJob(app)._run()
 
-            assert_s3_key_not_found(app, s3, 'sis-id-sis-import')
+            assert_s3_key_not_found(app, s3, 'sis-ids')
 
-            users_imported = read_s3_csv(app, s3, 'user-sis-import')
+            users_imported = read_s3_csv(app, s3, 'user-provision')
             assert len(users_imported) == 2
             assert users_imported[0] == 'user_id,login_id,first_name,last_name,email,status'
             assert users_imported[1] == '30030000,30000,Definitely-not-a-synthetic-Ash,🤖,synthetic.ash@berkeley.edu,active'
@@ -67,9 +67,9 @@ class TestBcoursesRefreshAccountsJob:
 
             BcoursesRefreshAccountsJob(app)._run()
 
-            assert_s3_key_not_found(app, s3, 'sis-id-sis-import')
+            assert_s3_key_not_found(app, s3, 'sis-ids')
 
-            users_imported = read_s3_csv(app, s3, 'user-sis-import')
+            users_imported = read_s3_csv(app, s3, 'user-provision')
             assert len(users_imported) == 2
             assert users_imported[0] == 'user_id,login_id,first_name,last_name,email,status'
             assert users_imported[1] == '30030000,30000,Ash,🤖,definitely.no.robots.here@berkeley.edu,active'
@@ -85,17 +85,17 @@ class TestBcoursesRefreshAccountsJob:
 
             BcoursesRefreshAccountsJob(app)._run()
 
-            sis_id_changes_imported = read_s3_csv(app, s3, 'sis-id-sis-import')
+            sis_id_changes_imported = read_s3_csv(app, s3, 'sis-ids')
             assert len(sis_id_changes_imported) == 2
             assert sis_id_changes_imported[0] == 'old_id,new_id,old_integration_id,new_integration_id,type'
             assert sis_id_changes_imported[1] == '30030000,1337,,,user'
 
-            assert_s3_key_not_found(app, s3, 'user-sis-import')
+            assert_s3_key_not_found(app, s3, 'user-provision')
 
     def test_no_enrollments_in_accounts_job(self, app):
         with setup_bcourses_refresh_job(app) as (s3, m):
             BcoursesRefreshAccountsJob(app)._run()
-            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B-sis-import')
+            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B')
 
     @pytest.fixture(scope='function')
     def campus_users(self, app):

--- a/tests/test_jobs/test_bcourses_refresh_full_job.py
+++ b/tests/test_jobs/test_bcourses_refresh_full_job.py
@@ -39,7 +39,7 @@ class TestBcoursesRefreshFullJob:
     def test_no_previous_export(self, app):
         with setup_bcourses_refresh_job(app) as (s3, m):
             BcoursesRefreshFullJob(app)._run()
-            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full-sis-import')
+            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full')
             assert len(spring_2023_enrollments_imported) == 4
             assert spring_2023_enrollments_imported[0] == 'course_id,user_id,role,section_id,status,associated_user_id'
             assert spring_2023_enrollments_imported[1] == 'CRS:ANTHRO-189-2023-B,30040000,student,SEC:2023-B-32936,active,'
@@ -49,7 +49,7 @@ class TestBcoursesRefreshFullJob:
     def test_previous_export_no_change(self, app):
         with self.setup_term_enrollments_export(app) as s3:
             BcoursesRefreshFullJob(app)._run()
-            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B-full-sis-import')
+            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B-full')
 
     @mock.patch('ripley.lib.canvas_site_provisioning.get_section_enrollments')
     def test_previous_export_student_added(self, mock_section_enrollments, app, section_enrollments):
@@ -66,7 +66,7 @@ class TestBcoursesRefreshFullJob:
             mock_section_enrollments.return_value = section_enrollments
 
             BcoursesRefreshFullJob(app)._run()
-            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full-sis-import')
+            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full')
             assert len(spring_2023_enrollments_imported) == 2
             assert spring_2023_enrollments_imported[1] == 'CRS:ANTHRO-189-2023-B,30060000,student,SEC:2023-B-32936,active,'
 
@@ -77,7 +77,7 @@ class TestBcoursesRefreshFullJob:
             mock_section_enrollments.return_value = section_enrollments
 
             BcoursesRefreshFullJob(app)._run()
-            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full-sis-import')
+            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full')
             assert len(spring_2023_enrollments_imported) == 2
             assert spring_2023_enrollments_imported[1] == 'CRS:ANTHRO-189-2023-B,30020000,student,SEC:2023-B-32936,deleted,'
 
@@ -96,7 +96,7 @@ class TestBcoursesRefreshFullJob:
             mock_section_instructors.return_value = section_instructors
 
             BcoursesRefreshFullJob(app)._run()
-            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full-sis-import')
+            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full')
             assert len(spring_2023_enrollments_imported) == 3
             assert spring_2023_enrollments_imported[1] == 'CRS:ANTHRO-189-2023-B,30020000,Lead TA,SEC:2023-B-32936,active,'
             assert spring_2023_enrollments_imported[2] == 'CRS:ANTHRO-189-2023-B,30020000,student,SEC:2023-B-32936,deleted,'
@@ -115,8 +115,8 @@ class TestBcoursesRefreshFullJob:
                 f.write(bytes('\n'.join(csv_rows) + '\n', encoding='utf-8'))
             upload_dated_csv(
                 export_file.name,
-                'TERM-2023-B-term-enrollments-export',
-                'canvas_provisioning_reports',
+                'enrollments-TERM-2023-B',
+                'canvas-provisioning-reports',
                 utc_now().strftime('%F_%H-%M-%S'),
             )
             yield s3

--- a/tests/test_jobs/test_bcourses_refresh_incremental_job.py
+++ b/tests/test_jobs/test_bcourses_refresh_incremental_job.py
@@ -42,7 +42,7 @@ class TestRefreshBcoursesIncremental:
     def test_no_previous_export(self, app):
         with self.setup_incremental_refresh_job(app) as s3:
             BcoursesRefreshIncrementalJob(app)._run()
-            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-incremental-sis-import')
+            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-incremental')
             assert len(spring_2023_enrollments_imported) == 4
             assert spring_2023_enrollments_imported[0] == 'course_id,user_id,role,section_id,status,associated_user_id'
             assert spring_2023_enrollments_imported[1] == 'CRS:ANTHRO-189-2023-B,30020000,student,SEC:2023-B-32936,active,'
@@ -52,14 +52,14 @@ class TestRefreshBcoursesIncremental:
     def test_incremental_job_does_not_duplicate_full_job(self, app):
         with setup_bcourses_refresh_job(app) as (s3, m):
             BcoursesRefreshFullJob(app)._run()
-            assert read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full-sis-import')
+            assert read_s3_csv(app, s3, 'enrollments-TERM-2023-B-full')
             BcoursesRefreshIncrementalJob(app)._run()
-            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B-incremental-sis-import')
+            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B-incremental')
 
     def test_previous_export_no_change(self, app):
         with self.setup_term_enrollments_export(app) as s3:
             BcoursesRefreshIncrementalJob(app)._run()
-            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B-incremental-sis-import')
+            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B-incremental')
 
     @mock.patch('ripley.lib.canvas_site_provisioning.get_edo_enrollment_updates')
     def test_previous_export_student_added(self, mock_edo_enrollment_updates, app, edo_enrollment_updates):
@@ -75,7 +75,7 @@ class TestRefreshBcoursesIncremental:
             mock_edo_enrollment_updates.return_value = edo_enrollment_updates
 
             BcoursesRefreshIncrementalJob(app)._run()
-            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-incremental-sis-import')
+            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-incremental')
             assert len(spring_2023_enrollments_imported) == 2
             assert spring_2023_enrollments_imported[1] == 'CRS:ANTHRO-189-2023-B,30060000,student,SEC:2023-B-32936,active,'
 
@@ -83,14 +83,14 @@ class TestRefreshBcoursesIncremental:
     def test_multiple_incremental_jobs_do_not_duplicate(self, mock_edo_enrollment_updates, app, edo_enrollment_updates):
         with self.setup_incremental_refresh_job(app) as s3:
             mock_edo_enrollment_updates.return_value = edo_enrollment_updates
-            assert count_s3_csvs(app, s3, 'enrollments-TERM-2023-B-incremental-sis-import') == 0
+            assert count_s3_csvs(app, s3, 'enrollments-TERM-2023-B-incremental') == 0
             BcoursesRefreshIncrementalJob(app)._run()
-            assert count_s3_csvs(app, s3, 'enrollments-TERM-2023-B-incremental-sis-import') == 1
+            assert count_s3_csvs(app, s3, 'enrollments-TERM-2023-B-incremental') == 1
             # Pause a moment to get a new timestamp.
             sleep(1)
             # No change, no new file.
             BcoursesRefreshIncrementalJob(app)._run()
-            assert count_s3_csvs(app, s3, 'enrollments-TERM-2023-B-incremental-sis-import') == 1
+            assert count_s3_csvs(app, s3, 'enrollments-TERM-2023-B-incremental') == 1
             sleep(1)
             # One new entry, one new file.
             edo_enrollment_updates.append({
@@ -103,8 +103,8 @@ class TestRefreshBcoursesIncremental:
             })
             mock_edo_enrollment_updates.return_value = edo_enrollment_updates
             BcoursesRefreshIncrementalJob(app)._run()
-            assert count_s3_csvs(app, s3, 'enrollments-TERM-2023-B-incremental-sis-import') == 2
-            latest_spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-incremental-sis-import', get_latest=True)
+            assert count_s3_csvs(app, s3, 'enrollments-TERM-2023-B-incremental') == 2
+            latest_spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-incremental', get_latest=True)
             assert len(latest_spring_2023_enrollments_imported) == 2
             assert latest_spring_2023_enrollments_imported[1] == 'CRS:ANTHRO-189-2023-B,30060000,student,SEC:2023-B-32936,active,'
 
@@ -117,7 +117,7 @@ class TestRefreshBcoursesIncremental:
             mock_edo_enrollment_updates.return_value = edo_enrollment_updates
 
             BcoursesRefreshIncrementalJob(app)._run()
-            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B-sis-import')
+            assert_s3_key_not_found(app, s3, 'enrollments-TERM-2023-B-full')
 
     @mock.patch('ripley.lib.canvas_site_provisioning.get_edo_enrollment_updates')
     @mock.patch('ripley.lib.canvas_site_provisioning.get_edo_instructor_updates')
@@ -138,7 +138,7 @@ class TestRefreshBcoursesIncremental:
             mock_edo_instructor_updates.return_value = edo_instructor_updates
 
             BcoursesRefreshIncrementalJob(app)._run()
-            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-incremental-sis-import')
+            spring_2023_enrollments_imported = read_s3_csv(app, s3, 'enrollments-TERM-2023-B-incremental')
             assert len(spring_2023_enrollments_imported) == 2
             assert spring_2023_enrollments_imported[1] == 'CRS:ANTHRO-189-2023-B,30020000,Lead TA,SEC:2023-B-32936,active,'
 
@@ -156,8 +156,8 @@ class TestRefreshBcoursesIncremental:
                 f.write(bytes('\n'.join(csv_rows) + '\n', encoding='utf-8'))
             upload_dated_csv(
                 export_file.name,
-                'user-provision-report',
-                'canvas_provisioning_reports',
+                'provisioned-users',
+                'canvas-provisioning-reports',
                 utc_now().strftime('%F_%H-%M-%S'),
             )
             yield s3
@@ -176,8 +176,8 @@ class TestRefreshBcoursesIncremental:
                 f.write(bytes('\n'.join(csv_rows) + '\n', encoding='utf-8'))
             upload_dated_csv(
                 export_file.name,
-                'TERM-2023-B-term-enrollments-export',
-                'canvas_provisioning_reports',
+                'enrollments-TERM-2023-B',
+                'canvas-provisioning-reports',
                 utc_now().strftime('%F_%H-%M-%S'),
             )
             yield s3

--- a/tests/test_jobs/test_export_term_enrollments_job.py
+++ b/tests/test_jobs/test_export_term_enrollments_job.py
@@ -54,8 +54,8 @@ class TestExportTermEnrollmentsJob:
             with mock_s3_bucket(app):
                 ExportTermEnrollmentsJob(app)._run(params={'sis_term_id': 'TERM:2023-B'})
 
-                csvs = find_last_dated_csvs('canvas_provisioning_reports', ['TERM-2023-B-term-enrollments-export'])
-                provisioning_report = csvs['TERM-2023-B-term-enrollments-export']
+                csvs = find_last_dated_csvs('canvas-provisioning-reports', ['enrollments-TERM-2023-B'])
+                provisioning_report = csvs['enrollments-TERM-2023-B']
                 rows = [r for r in csv.DictReader(stream_object_text(provisioning_report))]
 
                 assert len(rows) >= 1

--- a/tests/test_jobs/test_lti_usage_report_job.py
+++ b/tests/test_jobs/test_lti_usage_report_job.py
@@ -69,7 +69,7 @@ class TestLtiUsageReportJob:
             with mock_s3_bucket(app) as s3:
                 LtiUsageReportJob(app)._run()
 
-                summary_report = read_s3_csv(app, s3, 'lti_usage_summary-2023-B')
+                summary_report = read_s3_csv(app, s3, 'lti-usage-summary-2023-B')
                 assert len(summary_report) == 17
                 assert summary_report[0] == 'Tool,URL,Accounts,Courses Visible'
                 assert summary_report[1] == 'Canvas Data Portal,https://beta.example.com/session/lti/launch,1,N/A'
@@ -83,7 +83,7 @@ class TestLtiUsageReportJob:
                 assert summary_report[9] == 'Attendance,https://rollcall-beta.instructure.com/launch,129409,3'
                 assert summary_report[10] == 'Download E-Grades,https://ripley.berkeley.edu/api/lti/export_grade,129410,0'
 
-                courses_report = read_s3_csv(app, s3, 'lti_usage_courses-2023-B')
+                courses_report = read_s3_csv(app, s3, 'lti-usage-courses-2023-B')
                 assert len(courses_report) == 16
                 assert courses_report[0] == 'Course URL,Name,Tool,Teacher,Email'
                 assert courses_report[1] == 'https://hard_knocks_api.instructure.com/courses/1234567,COM LIT ABC,W. W. Norton,,'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-613

See Jira for link to documented new CSV naming scheme.

I also created a script for renaming the existing S3 objects to match (not included here).