### PR TITLE
RIP-676: removes '(LTI 1.3)' from newt's name

### DIFF
--- a/ripley/api/lti_controller.py
+++ b/ripley/api/lti_controller.py
@@ -87,12 +87,13 @@ def config_export_grade():
 
 @app.route('/api/lti/config/grade_distribution.json')
 def config_grade_distribution():
+    tool_definition = lti_tool_definitions()['grade_distribution']
     return tool_config(
-        default='disabled',
-        description='',
-        placement='course_navigation',
+        default=tool_definition['default'],
+        description=tool_definition['description'],
+        placement=tool_definition['placement'],
         target='launch_grade_distribution',
-        title='Grade Distribution (LTI 1.3)',
+        title=tool_definition['name'],
         visibility='admins',
     )
 

--- a/ripley/lib/canvas_lti.py
+++ b/ripley/lib/canvas_lti.py
@@ -91,10 +91,10 @@ def lti_tool_definitions():
                 'visibility': 'admins',
             },
             'grade_distribution': {
-                'name': 'Grade Distribution (LTI 1.3)',
+                'name': 'Grade Distribution',
                 'account_id': app.config['CANVAS_COURSES_ACCOUNT_ID'],
                 'client_id': '10720000000000632',
-                'description': 'Grade Distribution (LTI 1.3)',
+                'description': 'In-progress pilot project',
                 'placement': 'course_navigation',
                 'default': 'disabled',
                 'visibility': 'admins',

--- a/tests/test_api/test_lti_controller.py
+++ b/tests/test_api/test_lti_controller.py
@@ -95,9 +95,9 @@ class TestGetGradeDistributionConfig:
             client,
             config_uri='grade_distribution.json',
             expected_default='disabled',
-            expected_description='',
+            expected_description='In-progress pilot project',
             expected_placement='course_navigation',
-            expected_title='Grade Distribution (LTI 1.3)',
+            expected_title='Grade Distribution',
             expected_visibility='admins',
             target='launch_grade_distribution',
         )


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-676