### PR TITLE
RIP-748 Roster photos: consistent page breaks across browsers

### DIFF
--- a/src/components/bcourses/roster/RosterPhotos.vue
+++ b/src/components/bcourses/roster/RosterPhotos.vue
@@ -149,7 +149,11 @@ export default {
   *.v-card-roster-photo {
     margin: 0 !important;
   }
+  .photo-list {
+    display: table;
+  }
   .photo-wrapper {
+    float: none;
     width: 200px;
   }
   .photo-wrapper-one-per-page {


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-748