### PR TITLE
RIP-848 Remove TNIC from Newt permissions

### DIFF
--- a/ripley/api/grade_distribution_controller.py
+++ b/ripley/api/grade_distribution_controller.py
@@ -38,7 +38,7 @@ from ripley.merged.grade_distributions import get_grade_distribution_with_prior_
 
 
 @app.route('/api/grade_distribution/<canvas_site_id>')
-@canvas_role_required('TeacherEnrollment', 'TaEnrollment', 'Lead TA')
+@canvas_role_required('TeacherEnrollment', 'Lead TA')
 def get_grade_distribution(canvas_site_id):
     instructor_uid = None if current_user.is_admin else current_user.uid
     course, course_name, section_ids, term = _validate(canvas_site_id, instructor_uid)
@@ -84,7 +84,7 @@ def get_grade_distribution(canvas_site_id):
 
 
 @app.route('/api/grade_distribution/<canvas_site_id>/enrollment')
-@canvas_role_required('TeacherEnrollment', 'TaEnrollment', 'Lead TA')
+@canvas_role_required('TeacherEnrollment', 'Lead TA')
 def get_prior_enrollment_grade_distribution(canvas_site_id):
     instructor_uid = None if current_user.is_admin else current_user.uid
     course, course_name, section_ids, term = _validate(canvas_site_id, instructor_uid)
@@ -107,7 +107,7 @@ def get_prior_enrollment_grade_distribution(canvas_site_id):
 
 
 @app.route('/api/grade_distribution/search_courses')
-@canvas_role_required('TeacherEnrollment', 'TaEnrollment', 'Lead TA')
+@canvas_role_required('TeacherEnrollment', 'Lead TA')
 def search_courses():
     search_text = request.args.get('searchText')
     results = find_course_by_name(search_text)
@@ -132,6 +132,6 @@ def _validate(canvas_site_id, instructor_uid):
     section_ids = [s['id'] for s in sis_sections]
     term_id = term.to_sis_term_id()
 
-    if instructor_uid and not len(get_section_instructors(term_id, section_ids, instructor_uid=instructor_uid)):
+    if instructor_uid and not len(get_section_instructors(term_id, section_ids, instructor_uid=instructor_uid, roles=['PI', 'ICNT', 'APRX'])):
         raise UnauthorizedRequestError('Sorry, you are not authorized to use this tool.')
     return course, course_name, section_ids, term

--- a/tests/test_api/test_grade_distribution_controller.py
+++ b/tests/test_api/test_grade_distribution_controller.py
@@ -120,7 +120,7 @@ class TestGetGradeDistribution:
             ]
 
     def test_ta(self, client, app, fake_auth):
-        """Allows TA."""
+        """Denies TA."""
         with requests_mock.Mocker() as m, \
                 override_config(app, 'NEWT_SMALL_CELL_THRESHOLD', 0), \
                 override_config(app, 'NEWT_MINIMUM_CLASS_SIZE', 0):
@@ -136,7 +136,7 @@ class TestGetGradeDistribution:
             }, m)
             canvas_site_id = '8876542'
             fake_auth.login(canvas_site_id=canvas_site_id, uid=ta_uid)
-            _api_get_grade_distributions(client, canvas_site_id, expected_status_code=200)
+            _api_get_grade_distributions(client, canvas_site_id, expected_status_code=401)
 
     def test_non_pi_teacher(self, client, app, fake_auth):
         """Allows teacher who is not the primary instructor."""
@@ -342,7 +342,7 @@ class TestGetPriorEnrollmentGradeDistribution:
             ]
 
     def test_ta(self, client, app, fake_auth):
-        """Allows TA."""
+        """Denies TA."""
         with requests_mock.Mocker() as m:
             canvas_site_id = '8876542'
             register_canvas_uris(app, {
@@ -355,7 +355,7 @@ class TestGetPriorEnrollmentGradeDistribution:
                 'user': ['profile_50000'],
             }, m)
             fake_auth.login(canvas_site_id=canvas_site_id, uid=ta_uid)
-            _api_get_prior_enrollment_grade_distribution(client, canvas_site_id, expected_status_code=200)
+            _api_get_prior_enrollment_grade_distribution(client, canvas_site_id, expected_status_code=401)
 
     def test_non_pi_teacher(self, client, app, fake_auth):
         """Allows teacher who is not the primary instructor."""
@@ -540,7 +540,7 @@ class TestSearchCourses:
             assert response['results'] == ['ANTHRO 189', 'ANTHRO 197']
 
     def test_ta(self, client, app, fake_auth):
-        """Allows TA."""
+        """Denies TA."""
         with requests_mock.Mocker() as m:
             canvas_site_id = '8876542'
             register_canvas_uris(app, {
@@ -553,7 +553,7 @@ class TestSearchCourses:
                 'user': ['profile_50000'],
             }, m)
             fake_auth.login(canvas_site_id=canvas_site_id, uid=ta_uid)
-            _api_search_courses(client, expected_status_code=200)
+            _api_search_courses(client, expected_status_code=401)
 
     def test_teacher(self, client, app, fake_auth):
         """Allows teacher."""


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-848

Partial revert of #940.