### PR TITLE
RIP-991, Enable Enhanced CloudWatch Metrics

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -1,6 +1,107 @@
-#
-# AWS configuration for Ripley
-#
+files:
+  "/tmp/amazon-cloudwatch-agent.json":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      {
+        "agent": {
+          "metrics_collection_interval": 60,
+          "run_as_user": "root"
+        },
+        "metrics": {
+          "namespace": "CWAgent",
+          "append_dimensions": {
+            "AutoScalingGroupName": "${aws:AutoScalingGroupName}"
+          },
+          "aggregation_dimensions": [
+            ["AutoScalingGroupName"],
+            ["InstanceId"],
+            []
+          ],
+          "metrics_collected": {
+            "cpu": {
+              "measurement": [
+                "cpu_usage_idle",
+                "cpu_usage_system",
+                "cpu_usage_user",
+                "cpu_usage_iowait"
+              ],
+              "totalcpu": true,
+              "resources": [
+                "*"
+              ],
+              "metrics_collection_interval": 60
+            },
+            "mem": {
+              "measurement": [
+                "mem_used_percent",
+                "mem_available"
+              ],
+              "metrics_collection_interval": 300
+            },
+            "disk": {
+              "measurement": [
+                "disk_used_percent"
+              ],
+              "resources": [
+                "/"
+              ],
+              "drop_device": true,
+              "metrics_collection_interval": 300
+            },
+            "diskio": {
+              "measurement": [
+                "write_bytes",
+                "read_bytes",
+                "writes",
+                "reads"
+              ],
+              "resources": [
+                "*"
+              ],
+              "metrics_collection_interval": 300
+            },
+            "net": {
+              "measurement": [
+                "bytes_sent",
+                "bytes_recv"
+              ],
+              "resources": [
+                "eth0",
+                "ens*"
+              ],
+              "metrics_collection_interval": 300
+            }
+          }
+        },
+        "logs": {
+          "logs_collected": {
+            "files": {
+              "collect_list": [
+                {
+                  "file_path": "/var/app/current/ripley.log*",
+                  "log_group_name": "`{\"Fn::Join\":[\"/\", [\"/aws/elasticbeanstalk\", { \"Ref\":\"AWSEBEnvironmentName\" }, \"var/app/current/ripley.log\"]]}`",
+                  "log_stream_name": "{instance_id}"
+                },
+                {
+                  "file_path": "/var/log/messages",
+                  "log_group_name": "`{\"Fn::Join\":[\"/\", [\"/aws/elasticbeanstalk\", { \"Ref\":\"AWSEBEnvironmentName\" }, \"var/log/messages\"]]}`",
+                  "log_stream_name": "{instance_id}-messages",
+                  "timestamp_format": "%b %d %H:%M:%S"
+                },
+                {
+                  "file_path": "/var/log/secure",
+                  "log_group_name": "`{\"Fn::Join\":[\"/\", [\"/aws/elasticbeanstalk\", { \"Ref\":\"AWSEBEnvironmentName\" }, \"var/log/secure\"]]}`",
+                  "log_stream_name": "{instance_id}-secure",
+                  "timestamp_format": "%b %d %H:%M:%S"
+                }
+              ]
+            }
+          }
+        }
+      }
+
 packages:
   yum:
     gcc-c++: []
@@ -21,25 +122,3 @@ option_settings:
     /assets: dist/static/assets
     /canvas-customization: dist/static/canvas-customization
     /favicon.ico: dist/static/favicon.ico
-
-files:
-  /opt/aws/amazon-cloudwatch-agent/bin/config.json:
-    mode: '000644'
-    owner: root
-    group: root
-    content: |
-      {
-        "logs": {
-          "logs_collected": {
-            "files": {
-              "collect_list": [
-                {
-                  "file_path": "/var/app/current/ripley.log*",
-                  "log_group_name": "`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/current/ripley.log"]]}`",
-                  "log_stream_name": "{instance_id}"
-                }
-              ]
-            }
-          }
-        }
-      }

--- a/.platform/hooks/postdeploy/01_start_awslogsd.sh
+++ b/.platform/hooks/postdeploy/01_start_awslogsd.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json -s
+sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/tmp/amazon-cloudwatch-agent.json -s


### PR DESCRIPTION
Enable enhanced CloudWatch metrics. This was successfully tested with codepipeline connected to a forked repo/branch.