### PR TITLE
RIP-966 Mailing list creation: move canvas site ID into API path

### DIFF
--- a/ripley/api/mailing_lists_controller.py
+++ b/ripley/api/mailing_lists_controller.py
@@ -64,12 +64,11 @@ def welcome_email_activate():
         raise ResourceNotFoundError(f'bCourses site {current_user.canvas_site_id} has no mailing list.')
 
 
-@app.route('/api/mailing_list/create', methods=['POST'])
+@app.route('/api/mailing_list/<canvas_site_id>/create', methods=['POST'])
 @canvas_role_required('TeacherEnrollment', 'TaEnrollment', 'Lead TA', 'Reader', 'CanvasAdmin')
-def create_mailing_lists():
+def create_mailing_list(canvas_site_id):
     try:
         params = request.get_json()
-        canvas_site_id = params.get('canvasSiteId')
         populate = params.get('populate') or False
         canvas_site = canvas.get_course(canvas_site_id) if canvas_site_id else None
         if not canvas_site:

--- a/src/api/mailing-list.ts
+++ b/src/api/mailing-list.ts
@@ -12,7 +12,7 @@ export function createMailingList(
   populate: boolean,
   redirectOnError?: boolean
 ) {
-  return utils.post('/api/mailing_list/create', {canvasSiteId, name, populate}, redirectOnError)
+  return utils.post(`/api/mailing_list/${canvasSiteId}/create`, {name, populate}, redirectOnError)
 }
 
 export function deactivateWelcomeEmail() {

--- a/tests/test_api/test_mailing_list_controller.py
+++ b/tests/test_api/test_mailing_list_controller.py
@@ -614,11 +614,11 @@ def _api_create_mailing_list(
         expected_status_code=200,
         name=None,
 ):
-    params = {'canvasSiteId': canvas_site_id}
+    params = {}
     if name:
         params['name'] = name
     response = client.post(
-        '/api/mailing_list/create',
+        f'/api/mailing_list/{canvas_site_id}/create',
         data=json.dumps(params),
         content_type='application/json',
     )


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-966

Site ID in the API path is necessary for the `@canvas_role_required` auth decorator to work properly.