### PR TITLE
RIP-1064 Include term-after-next in official sections feed

### DIFF
--- a/ripley/api/canvas_site_controller.py
+++ b/ripley/api/canvas_site_controller.py
@@ -94,9 +94,11 @@ def manage_official_sections():
     canvas_courses = canvas.get_user_courses(current_user.uid)
     terms = BerkeleyTerm.get_current_terms()
     api_json = {}
-    for term in [terms['current'], terms['next']]:
-        term_id = term.to_sis_term_id()
-        sis_term_id = term.to_canvas_sis_term_id()
+    for term_key in ['current', 'next', 'future']:
+        if term_key not in terms:
+            continue
+        term_id = terms[term_key].to_sis_term_id()
+        sis_term_id = terms[term_key].to_canvas_sis_term_id()
         api_json[term_id] = []
         for canvas_course in canvas_courses:
             if 'sis_term_id' in canvas_course.term and canvas_course.term['sis_term_id'] == sis_term_id:

--- a/tests/test_api/test_canvas_site_controller.py
+++ b/tests/test_api/test_canvas_site_controller.py
@@ -31,6 +31,7 @@ from tests.util import hypersleep, override_config, register_canvas_uris
 
 TERM_ID_CURRENT = '2232'
 TERM_ID_NEXT = '2235'
+TERM_ID_FUTURE = '2238'
 
 admin_uid = '10000'
 faculty_uid = '90000'
@@ -44,7 +45,7 @@ teacher_uid = '30000'
 
 class TestViewOfficialSections:
 
-    EMPTY_OFFICIAL_SECTIONS_FEED = {TERM_ID_CURRENT: [], TERM_ID_NEXT: []}
+    EMPTY_OFFICIAL_SECTIONS_FEED = {TERM_ID_CURRENT: [], TERM_ID_NEXT: [], TERM_ID_FUTURE: []}
 
     @classmethod
     def _api_canvas_site_official_sections(cls, client, expected_status_code=200):


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/RIP-1064

Far-future terms have been omitted from Official Sections ever since we took the tool out of course navigation and folded it under "Create & Manage Sites," but there doesn't seem to be any need for that omission.